### PR TITLE
An almost working implementation to install from .whl

### DIFF
--- a/examples/whl.py
+++ b/examples/whl.py
@@ -42,11 +42,11 @@ class ZipFileInstaller(object):
     """Install a local wheel.
     """
 
-    def __init__(self, name, dist_info, zip_file_handler):
+    def __init__(self, name, dist_info, zip_file_handle):
         # type: (str, DistInfo, zipfile.ZipFile) -> None
         self._name = name
         self._dist_info = dist_info
-        self._zip_file_handler = zip_file_handler
+        self._zip_file_handle = zip_file_handle
 
     @classmethod
     @contextlib.contextmanager
@@ -85,7 +85,7 @@ class ZipFileInstaller(object):
 
     def _install_record_item(self, item, directory):
         # type: (RecordItem, pathlib.Path) -> None
-        with self._zip_file_handler.open(str(item.path)) as f:
+        with self._zip_file_handle.open(str(item.path)) as f:
             data = f.read()
         item.raise_for_validation(data)
         target = directory.joinpath(item.path)
@@ -95,7 +95,7 @@ class ZipFileInstaller(object):
 
     def _iter_installed_record_items(self, directory):
         # type: (pathlib.Path) -> Iterator[RecordItem]
-        with self._zip_file_handler.open(str(self._dist_info.record)) as f:
+        with self._zip_file_handle.open(str(self._dist_info.record)) as f:
             for item in parse_record_file(_wrap_as_io_str(f)):
                 self._install_record_item(item, directory)
                 yield item

--- a/examples/whl.py
+++ b/examples/whl.py
@@ -69,6 +69,7 @@ class ZipFileInstaller(object):
         target = directory.joinpath(item.path)
         with self._open_target_for_write(target, binary=True) as f:
             f.write(data)
+        # TODO: Handle file permission and other metadata.
 
     def _iter_installed_record_items(self, directory):
         # type: (pathlib.Path) -> Iterator[RecordItem]
@@ -100,9 +101,11 @@ class ZipFileInstaller(object):
     def install(self, directory):
         # type: (pathlib.Path) -> None
         items = {r.path: r for r in self._iter_installed_record_items(directory)}
+        # TODO: Install .data directory.
         items.update((r.path, r) for r in self._iter_installed_scripts(directory))
         items.update((r.path, r) for r in self._write_additional_metadata(directory))
         self._write_record(directory, items)
+        # TODO: Compile .pyc files.
 
 
 def main(args=None):

--- a/examples/whl.py
+++ b/examples/whl.py
@@ -42,11 +42,11 @@ class ZipFileInstaller(object):
     """Install a local wheel.
     """
 
-    def __init__(self, name, distinfo, zf):
+    def __init__(self, name, distinfo, zip_file_handler):
         # type: (str, DistInfo, zipfile.ZipFile) -> None
         self._name = name
         self._distinfo = distinfo
-        self._zf = zf
+        self._zip_file_handler = zip_file_handler
 
     @classmethod
     @contextlib.contextmanager
@@ -85,7 +85,7 @@ class ZipFileInstaller(object):
 
     def _install_record_item(self, item, directory):
         # type: (RecordItem, pathlib.Path) -> None
-        with self._zf.open(str(item.path)) as f:
+        with self._zip_file_handler.open(str(item.path)) as f:
             data = f.read()
         item.raise_for_validation(data)
         target = directory.joinpath(item.path)
@@ -95,7 +95,7 @@ class ZipFileInstaller(object):
 
     def _iter_installed_record_items(self, directory):
         # type: (pathlib.Path) -> Iterator[RecordItem]
-        with self._zf.open(str(self._distinfo.record)) as f:
+        with self._zip_file_handler.open(str(self._distinfo.record)) as f:
             for item in parse_record_file(_wrap_as_io_str(f)):
                 self._install_record_item(item, directory)
                 yield item

--- a/examples/whl.py
+++ b/examples/whl.py
@@ -1,0 +1,120 @@
+"""Install from a .whl file.
+"""
+
+import argparse
+import codecs
+import contextlib
+import sys
+import zipfile
+
+from installer._compat import pathlib
+from installer._compat.typing import TYPE_CHECKING
+from installer.layouts import DistInfo
+from installer.records import RecordItem, parse_record_file, write_record_file
+
+if TYPE_CHECKING:
+    from typing import Any, ContextManager, Dict, IO, Iterator
+
+
+class ZipFileInstaller(object):
+    """Install a local wheel.
+    """
+
+    def __init__(self, name, distinfo, zf):
+        # type: (str, DistInfo, zipfile.ZipFile) -> None
+        self._name = name
+        self._distinfo = distinfo
+        self._zf = zf
+
+    @classmethod
+    @contextlib.contextmanager
+    def create(cls, name, wheel_path):
+        # type: (str, pathlib.Path) -> Iterator[ZipFileInstaller]
+        project_name, project_version, _ = wheel_path.stem.split("-", 2)
+        with zipfile.ZipFile(str(wheel_path)) as zf:
+            entry_names = (name.lstrip("/").split("/", 1)[0] for name in zf.namelist())
+            distinfo = DistInfo.find(project_name, project_version, entry_names)
+            yield cls(name, distinfo, zf)
+
+    @contextlib.contextmanager
+    def _open_adjacent_tmp_for_write(self, path, **kwargs):
+        # type: (pathlib.Path, Any) -> Iterator[IO[Any]]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp = path.with_name("{}.tmp.{}".format(path.name, self._name))
+        with temp.open(**kwargs) as f:
+            yield f
+        temp.replace(path)
+
+    def _open_target_for_write(self, path, binary=False):
+        # type: (pathlib.Path, bool) -> ContextManager[IO[Any]]
+        if binary:
+            kwargs = {"mode": "wb"}
+        else:
+            kwargs = {"mode": "w", "encoding": "utf-8"}
+        return self._open_adjacent_tmp_for_write(path, **kwargs)
+
+    def _open_csv_for_write(self, path):
+        # type: (pathlib.Path) -> ContextManager[IO[Any]]
+        if sys.version_info < (3,):
+            kwargs = {"mode": "wb"}
+        else:
+            kwargs = {"mode": "w", "newline": "", "encoding": "utf-8"}
+        return self._open_adjacent_tmp_for_write(path, **kwargs)
+
+    def _install_record_item(self, item, directory):
+        # type: (RecordItem, pathlib.Path) -> None
+        with self._zf.open(str(item.path)) as f:
+            data = f.read()
+        item.raise_for_validation(data)
+        target = directory.joinpath(item.path)
+        with self._open_target_for_write(target, binary=True) as f:
+            f.write(data)
+
+    def _iter_installed_record_items(self, directory):
+        # type: (pathlib.Path) -> Iterator[RecordItem]
+        reader = codecs.getreader("utf-8")
+        with self._zf.open(str(self._distinfo.record)) as f:
+            for item in parse_record_file(reader(f)):
+                self._install_record_item(item, directory)
+                yield item
+
+    def _iter_installed_scripts(self, directory):
+        # type: (pathlib.Path) -> Iterator[RecordItem]
+        return iter(())  # TODO: Implement me.
+
+    def _write_additional_metadata(self, directory):
+        # type: (pathlib.Path) -> Iterator[RecordItem]
+        installer = directory.joinpath(self._distinfo.installer)
+        with self._open_target_for_write(installer) as f:
+            f.write(self._name)
+        yield RecordItem(self._distinfo.installer, None, None)
+        # TODO: Write direct_url.json.
+
+    def _write_record(self, directory, installed_items):
+        # type: (pathlib.Path, Dict[pathlib.PurePosixPath, RecordItem]) -> None
+        record = self._distinfo.record
+        installed_items[record] = RecordItem(record, None, None)
+        with self._open_csv_for_write(directory.joinpath(record)) as f:
+            write_record_file(f, installed_items.values())
+
+    def install(self, directory):
+        # type: (pathlib.Path) -> None
+        items = {r.path: r for r in self._iter_installed_record_items(directory)}
+        items.update((r.path, r) for r in self._iter_installed_scripts(directory))
+        items.update((r.path, r) for r in self._write_additional_metadata(directory))
+        self._write_record(directory, items)
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel", type=pathlib.Path)
+    parser.add_argument("dest", type=pathlib.Path)
+    parser.add_argument("--installer", default="pypa-installer")
+
+    options = parser.parse_args(args)
+    with ZipFileInstaller.create(options.installer, options.wheel) as installer:
+        installer.install(options.dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ description-file = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 requires = [
-  "pathlib2; python_version < '3.4'"
+  "pathlib2; python_version < '3.4'",
+  "six",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/src/installer/_compat/pathlib.py
+++ b/src/installer/_compat/pathlib.py
@@ -1,8 +1,8 @@
-__all__ = ["PurePosixPath"]
+__all__ = ["Path", "PurePath", "PurePosixPath"]
 
 import sys
 
 if sys.version_info >= (3, 4):  # pragma: no cover
-    from pathlib import PurePosixPath
+    from pathlib import Path, PurePath, PurePosixPath
 else:  # pragma: no cover
-    from pathlib2 import PurePosixPath
+    from pathlib2 import Path, PurePath, PurePosixPath

--- a/src/installer/_compat/pathlib.py
+++ b/src/installer/_compat/pathlib.py
@@ -1,6 +1,6 @@
-__all__ = ["Path", "PurePath", "PurePosixPath"]
-
 import sys
+
+__all__ = ["Path", "PurePath", "PurePosixPath"]
 
 if sys.version_info >= (3, 4):  # pragma: no cover
     from pathlib import Path, PurePath, PurePosixPath

--- a/src/installer/_compat/typing.py
+++ b/src/installer/_compat/typing.py
@@ -1,6 +1,6 @@
-__all__ = ["TYPE_CHECKING"]
-
 try:  # pragma: no cover
     from typing import TYPE_CHECKING
 except ImportError:  # pragma: no cover
     TYPE_CHECKING = False
+
+__all__ = ["TYPE_CHECKING"]

--- a/src/installer/exceptions.py
+++ b/src/installer/exceptions.py
@@ -1,0 +1,27 @@
+__all__ = [
+    "InvalidWheel",
+    "MetadataNotFound",
+    "RecordItemError",
+    "RecordItemHashMismatch",
+    "RecordItemSizeMismatch",
+]
+
+
+class InvalidWheel(Exception):
+    pass
+
+
+class MetadataNotFound(InvalidWheel):
+    pass
+
+
+class RecordItemError(InvalidWheel):
+    pass
+
+
+class RecordItemHashMismatch(RecordItemError):
+    pass
+
+
+class RecordItemSizeMismatch(RecordItemError):
+    pass

--- a/src/installer/layouts.py
+++ b/src/installer/layouts.py
@@ -46,6 +46,8 @@ def _version_escape(v):
 
 
 class DistInfo(object):
+    _EXTENSION = ".dist-info"
+
     def __init__(self, directory_name):
         # type: (str) -> None
         self.directory_name = directory_name
@@ -58,7 +60,7 @@ class DistInfo(object):
 
         for entry_name in entry_names:
             stem, ext = os.path.splitext(entry_name)
-            if ext.lower() != ".dist-info":
+            if ext.lower() != cls._EXTENSION:
                 continue
             name, _, version = stem.partition("-")
             if not version:  # Dash not found.
@@ -71,8 +73,8 @@ class DistInfo(object):
             # correctly build paths with pathlib2, which does not take unicode.
             return cls(six.ensure_str(entry_name))
 
-        expected_name = "{}-{}.dist-info".format(
-            escaped_project_name, escaped_project_version,
+        expected_name = "{}-{}{}".format(
+            escaped_project_name, escaped_project_version, cls._EXTENSION,
         )
         raise MetadataNotFound(expected_name)
 

--- a/src/installer/layouts.py
+++ b/src/installer/layouts.py
@@ -1,0 +1,83 @@
+__all__ = ["DistInfo"]
+
+import os
+import re
+
+from installer._compat import pathlib
+from installer._compat.typing import TYPE_CHECKING
+from installer.exceptions import MetadataNotFound
+
+if TYPE_CHECKING:
+    from typing import Iterable
+
+
+_NAME_ESCAPE_REGEX = re.compile(r"[^A-Za-z0-9]+")
+
+_VERSION_ESCAPE_REGEX = re.compile(r"[^A-Za-z0-9\.]+")
+
+
+def _name_escape(s):
+    # type: (str) -> str
+    """Filename-escape the distribution name according to PEP 376.
+
+    1. Replace any runs of non-alphanumeric characters with a single ``-``.
+    2.  Any ``-`` characters are replaced with ``_``.
+    """
+    return _NAME_ESCAPE_REGEX.sub("_", s)
+
+
+def _version_escape(v):
+    # type: (str) -> str
+    """Filename-escape the version string according to PEP 376.
+
+    1. Spaces become dots, and all other non-alphanumeric characters (except
+       dots) become dashes, with runs of multiple dashes condensed to a single
+       dash.
+    2. Any ``-`` characters are replaced with ``_``.
+    """
+    return _VERSION_ESCAPE_REGEX.sub("_", v.replace(" ", "."))
+
+
+class DistInfo(object):
+    def __init__(self, directory_name):
+        # type: (str) -> None
+        self.directory_name = directory_name
+
+    @classmethod
+    def find(cls, project_name, project_version, entry_names):
+        # type: (str, str, Iterable[str]) -> DistInfo
+        escaped_project_name = _name_escape(project_name).lower()
+        escaped_project_version = _version_escape(project_version)
+
+        for entry_name in entry_names:
+            stem, ext = os.path.splitext(entry_name)
+            if ext.lower() != ".dist-info":
+                continue
+            name, _, version = stem.partition("-")
+            if not version:  # Dash not found.
+                continue
+            if escaped_project_name != _name_escape(name).lower():
+                continue
+            if escaped_project_version != _version_escape(version):
+                continue
+            return cls(entry_name)
+
+        expected_name = "{}-{}.dist-info".format(
+            escaped_project_name, escaped_project_version,
+        )
+        raise MetadataNotFound(expected_name)
+
+    @property
+    def record(self):
+        # type: () -> pathlib.PurePosixPath
+        return pathlib.PurePosixPath(self.directory_name, "RECORD")
+
+    @property
+    def installer(self):
+        # type: () -> pathlib.PurePosixPath
+        return pathlib.PurePosixPath(self.directory_name, "INSTALLER")
+
+    @property
+    def direct_url_json(self):
+        # type: () -> pathlib.PurePosixPath
+        return pathlib.PurePosixPath(self.directory_name, "direct_url.json")

--- a/src/installer/layouts.py
+++ b/src/installer/layouts.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 __all__ = ["DistInfo"]
 
+
 _NAME_ESCAPE_REGEX = re.compile(r"[^A-Za-z0-9]+")
 
 _VERSION_ESCAPE_REGEX = re.compile(r"[^A-Za-z0-9\.]+")

--- a/src/installer/layouts.py
+++ b/src/installer/layouts.py
@@ -1,5 +1,3 @@
-__all__ = ["DistInfo"]
-
 import os
 import re
 
@@ -17,6 +15,7 @@ if TYPE_CHECKING:
     else:
         FileName = str
 
+__all__ = ["DistInfo"]
 
 _NAME_ESCAPE_REGEX = re.compile(r"[^A-Za-z0-9]+")
 

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -1,10 +1,3 @@
-__all__ = [
-    "Hash",
-    "RecordItem",
-    "SuperfulousRecordColumnsWarning",
-    "parse_record_file",
-]
-
 import base64
 import csv
 import hashlib
@@ -23,6 +16,14 @@ if TYPE_CHECKING:
         def write(self, s):
             # type: (str) -> int
             pass
+
+
+__all__ = [
+    "Hash",
+    "RecordItem",
+    "SuperfulousRecordColumnsWarning",
+    "parse_record_file",
+]
 
 
 class SuperfulousRecordColumnsWarning(UserWarning):

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -17,7 +17,12 @@ from installer._compat.typing import TYPE_CHECKING
 from installer.exceptions import RecordItemHashMismatch, RecordItemSizeMismatch
 
 if TYPE_CHECKING:
-    from typing import IO, Iterable, Iterator, Optional, Tuple
+    from typing import Iterable, Iterator, Optional, Protocol, Tuple
+
+    class _Writable(Protocol):
+        def write(self, s):
+            # type: (str) -> None
+            pass
 
 
 class SuperfulousRecordColumnsWarning(UserWarning):
@@ -115,6 +120,6 @@ def parse_record_file(f):
 
 
 def write_record_file(f, items):
-    # type: (IO[str], Iterable[RecordItem]) -> None
+    # type: (_Writable, Iterable[RecordItem]) -> None
     writer = csv.writer(f)
     writer.writerows(sorted(item.as_row() for item in items))

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -51,7 +51,7 @@ class Hash(object):
         digest = hashlib.new(self.name, data).digest()
         value = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
         if value != self.value:
-            raise RecordItemHashMismatch(self, value)
+            raise RecordItemHashMismatch(self, data)
 
 
 class RecordItem(object):
@@ -89,10 +89,10 @@ class RecordItem(object):
 
     def raise_for_validation(self, data):
         # type: (six.binary_type) -> None
+        if self.size is not None and self.size != len(data):
+            raise RecordItemSizeMismatch(self.size, data)
         if self.hash_ is not None:
             self.hash_.raise_for_validation(data)
-        if self.size is not None and self.size != len(data):
-            raise RecordItemSizeMismatch(self, data)
 
     def as_row(self):
         # type: () -> Tuple[str, str, str]

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     class _Writable(Protocol):
         def write(self, s):
-            # type: (str) -> None
+            # type: (str) -> int
             pass
 
 

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -1,0 +1,57 @@
+import re
+
+import pytest
+
+from installer.exceptions import MetadataNotFound
+from installer.layouts import DistInfo
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "pytest-cov",  # Normalized.
+        "Pytest-Cov",  # Different casing.
+        "Pytest_cov",  # Underscore.
+        "pytest.Cov",  # Dot.
+    ],
+)
+@pytest.mark.parametrize(
+    "directory_name",
+    [
+        "pytest_cov-2.11.2.dist-info",
+        "Pytest_Cov-2.11.2.dist-info",
+        "Pytest_Cov-2 11 2.dist-info",
+    ],
+)
+def test_find_distinfo(name, directory_name):
+    entries = [
+        "pytest_xdist-2.8.1.dist-info",
+        "pytest-2.8.1.dist-info",
+        "pytest_cov",
+        "{}-2.8.2.dist-info".format(re.sub(r"[-_\.]+", "_", name)),
+        directory_name,
+    ]
+    distinfo = DistInfo.find(name, "2.11.2", entries)
+    assert distinfo.directory_name == directory_name
+
+
+@pytest.mark.parametrize(
+    "directory_name",
+    [
+        "pytest_cov-2.8.1.egg-info",  # Wrong extension.
+        "pytest_cov.dist-info",  # No version.
+        "pytest_coverage-2.8.1.dist-info",  # Wrong name.
+        "pytest_cov-2.8.2.dist-info",  # Wrong version.
+        "pytest-cov-2.8.1.dist-info",  # Wrong name format.
+    ],
+)
+def test_find_distinfo_error(directory_name):
+    entries = [
+        "pytest_xdist-2.8.1.dist-info",
+        "pytest-2.8.1.dist-info",
+        "pytest_cov",
+        directory_name,
+    ]
+    with pytest.raises(MetadataNotFound) as ctx:
+        DistInfo.find("pytest-cov", "2.8.1", entries)
+    assert str(ctx.value) == "pytest_cov-2.8.1.dist-info"

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -15,7 +15,7 @@ from installer.records import (
     RecordItem,
     SuperfulousRecordColumnsWarning,
     parse_record_file,
-    write_record_file
+    write_record_file,
 )
 
 
@@ -148,10 +148,7 @@ def test_write_record(record_simple):
 # Record item describing a file "greeting" with content b"Hello".
 HELLO_RECORD_ITEM = RecordItem(
     path=pathlib.PurePosixPath("greeting"),
-    hash_=Hash(
-        name="sha256",
-        value="GF-NsyJx_iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk=",
-    ),
+    hash_=Hash(name="sha256", value="GF-NsyJx_iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk="),
     size=5,
 )
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,5 +1,4 @@
 import io
-import os
 
 import pytest
 import six
@@ -141,7 +140,7 @@ def test_write_record(record_simple):
     buffer = _get_csv_io()
     write_record_file(buffer, record_items)
 
-    expected = os.linesep.join(sorted(record_simple)) + os.linesep
+    expected = "\r\n".join(sorted(record_simple)) + "\r\n"
     assert buffer.getvalue() == expected
 
 


### PR DESCRIPTION
I implemented the whole workflow to identify what are the missing pieces. And it’s almost working!

```console
$ py examples/whl.py <..whl> <directory> [--installer <installer-name>]
```

(See pypa/pip#8156 for background of the installer name feature.)

There are two areas I have not implemented:

* Script generation. This is probably the most hairy part unimplmented. I’ll probably go ~copy~ reference parts of distlib.
* PEP 610 (`direct_url.json`). I’m not sure about how we should implement this. pip already has an implementation, but I don’t feel like copying it directly since we only need a small subset of it (to write the file, not read and make sense of it). Maybe we should put it somewhere instead, e.g. `packaging` or `importlib-metadata`? The installer can just accept an optional `DirectURL` instance and work with that.

And then we can start identifying features we can make sans-IO. I already pulled out a part of making sense of the wheel structure (where the `.dist-info` directory is, and format various files in it). Some other potential parts I can think of:

* Metadata generation (other than `RECORD`). Especially if we have PEP 610 support, since that is more than writing a string to a file.
* Keeping track of the installed files. Currently the example is using a dict to do this, but maybe we can have a Recorder (I’m terrible at naming) class to encapsulate the logic.