### PR TITLE
records: add RecordItem.validate()

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203
+extend-ignore = E203,E501

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -1,7 +1,9 @@
 """Utilities for parsing and handling PEP 376 RECORD files.
 """
 
+import base64
 import csv
+import hashlib
 import os
 
 from installer._compat.typing import TYPE_CHECKING
@@ -64,6 +66,18 @@ class Record(object):
         return "Record(path={!r}, hash_={!r}, size={!r})".format(
             self.path, self.hash_, self.size,
         )
+
+    def validate(self, data):
+        # type: (bytes) -> bool
+        if self.size is not None and len(data) != self.size:
+            return False
+
+        if self.hash_:
+            digest = hashlib.new(self.hash_.name, data).digest()
+            value = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+            return self.hash_.value == value
+
+        return True
 
     @classmethod
     def from_elements(cls, path, hash_, size):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -66,6 +66,44 @@ class TestRecord:
     def test_valid_elements(self, path, hash_, size):
         Record.from_elements(path, hash_, size)
 
+    @pytest.mark.parametrize(
+        ("elements", "data", "expected"),
+        [
+            (
+                ("test1.py", "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4", 6),
+                b"test1\n",
+                True,
+            ),
+            (
+                ("test2.py", "sha256=fW_Xd08Nh2JNptzxbQ09EEwxkedx--LznIau1LK_Gg8", 6),
+                b"test2\n",
+                True,
+            ),
+            (
+                ("test3.py", "sha256=qwPDTx7OCCEf4qgDn9ZCQZmz9de1X_E7ETSzZHdsRcU", 6),
+                b"test3\n",
+                True,
+            ),
+            (
+                ("test4.py", "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4", 7),
+                b"test1\n",
+                False,
+            ),
+            (
+                (
+                    "test5.py",
+                    "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4",
+                    None,
+                ),
+                b"test1\n",
+                True,
+            ),
+            (("test6.py", None, None), b"test1\n", True),
+        ],
+    )
+    def test_parse_record(self, elements, data, expected):
+        assert Record.from_elements(*elements).validate(data) == expected
+
 
 class TestParseRecordFile:
     def test_accepts_empty_iterable(self):


### PR DESCRIPTION
I opted for `validate` to receive `bytes` as this should be compatible with both `ZipFile` and normal files, but this *could* be a problem with big files. What do you think?

If we choose to receive a `BinaryIO` instead of `bytes` it could be tricky to get the size. I guess if the object is seekable, we can seek to the end and use `tell`.