### PR TITLE
Cache nox & pip in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Get nox cache
-    - name: Save date (for cache)
-      id: date
-      run: echo "::set-output name=date::$(date +%F)"
-    - uses: actions/cache@v1
-      with:
-        path: ${{ github.workspace }}/.nox
-        key: nox-v1-${{ runner.os }}-${{ steps.date.outputs.date }}
-        restore-keys: nox-v1-${{ runner.os }}
-
     # Get all the Python versions
     - uses: actions/setup-python@v1
       with: {python-version: pypy2}
@@ -42,6 +32,26 @@ jobs:
       with: {python-version: 3.7}
     - uses: actions/setup-python@v1
       with: {python-version: 3.8}
+
+    # Get cache
+    - name: Save date (for cache)
+      id: date
+      run: echo "::set-output name=date::$(date +%F)"
+    - name: Save pip cache dir
+      id: pip-cache-dir
+      run: echo "::set-output name=dir::$(pip cache dir)"
+    - name: nox cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/.nox
+        key: nox-v1-${{ runner.os }}-${{ steps.date.outputs.date }}
+        restore-keys: nox-v1-${{ runner.os }}
+    - name: pip cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.pip-cache-dir.outputs.dir }}
+        key: pip-v1-${{ runner.os }}-${{ steps.date.outputs.date }}
+        restore-keys: pip-v1-${{ runner.os }}
 
     - run: pip install nox
     - run: nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Get nox cache
+    - name: Save date (for cache)
+      id: date
+      run: echo "::set-output name=date::$(date +%F)"
+    - uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/.nox
+        key: nox-v1-${{ runner.os }}-${{ steps.date.outputs.date }}
+        restore-keys: nox-v1-${{ runner.os }}
+
     # Get all the Python versions
     - uses: actions/setup-python@v1
       with: {python-version: pypy2}


### PR DESCRIPTION
From `ci: cache nox`
> Right now, we recreate the nox environment on every CI run, which is wasteful
> as it can take a while to to create it.
>
> This patch caches the nox environment so that it doesn't need to be
> recreated on every CI run. The cache will only be updated once a day.
>
> If at some point we save a bad environment or the cached environment
> becomes incompatible with newer nox versions, we should bump the
> version (currently v1) in the cache key, to force the cache to be
> recreated.
>
> Signed-off-by: Filipe Laíns <lains@archlinux.org>