### PR TITLE
Initial implementation

### DIFF
--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -1,0 +1,113 @@
+"""Wheel Installation logic, sans I/O
+"""
+
+import posixpath
+
+from installer._compat import StringIO
+from installer._compat.typing import TYPE_CHECKING
+from installer.parsers import parse_metadata_file
+from installer.protocols import Destination, Scheme, WheelSource
+from installer.validation import InvalidWheelSource
+
+if TYPE_CHECKING:
+    from typing import Callable, List, Optional
+
+    from installer._compat.typing import Text
+
+    Validator = Callable[[WheelSource], None]
+
+
+__all__ = ["Installer"]
+
+
+class Installer(object):
+    """Implements wheel installation logic
+
+    Supports Wheel version 1.0 (PEP 427).
+    """
+
+    def __init__(self, name, validators):
+        # type: (Optional[Text], List[Validator]) -> None
+        super(Installer, self).__init__()
+        self.name = name
+        self._validators = validators
+
+    def install(self, source, destination, requested=False):
+        # type: (WheelSource, Destination, bool) -> None
+        """Install a wheel, as described by ``source``, to ``destination``.
+        """
+
+        # Process the WHEEL file
+        wheel_metadata_stream = source.open_dist_info(u"WHEEL")
+        metadata = parse_metadata_file(wheel_metadata_stream)
+
+        # Ensure compatibility with this wheel version.
+        if metadata["Wheel-Version"] != "1.0":
+            raise InvalidWheelSource(
+                source, "Incompatible Wheel-Version: only support version 1.0",
+            )
+
+        self._pass_through_validators(source)
+
+        # Determine where archive root should go.
+        if metadata["Root-Is-Purelib"]:
+            root_scheme = Scheme.purelib
+        else:
+            root_scheme = Scheme.platlib
+
+        # Unpack all the files, directly into the correct scheme.
+        for path, stream in source.iter_files():
+            scheme = self._determine_scheme(path, source=source, fallback=root_scheme)
+            destination.write_file(scheme=scheme, path=path, stream=stream)
+
+        # Write INSTALLER, if name is provided.
+        if self.name is not None:
+            destination.write_file(
+                scheme=root_scheme,
+                path=posixpath.join(source.dist_info, u"INSTALLER"),
+                stream=StringIO(self.name),
+            )
+        # Write REQUESTED, if requested.
+        if requested:
+            destination.write_file(
+                scheme=root_scheme,
+                path=posixpath.join(source.dist_info, u"REQUESTED"),
+                stream=StringIO(u""),
+            )
+
+        # Rewrite the RECORD at the end.
+        destination.rewrite_record(scheme=root_scheme)
+
+    def _pass_through_validators(self, source):
+        # type: (WheelSource) -> None
+        errors = []
+        for validator in self._validators:
+            try:
+                validator(source)
+            except InvalidWheelSource as e:
+                errors.append(e)
+
+        if errors:
+            raise InvalidWheelSource.from_multiple(source, errors)
+
+    def _determine_scheme(self, path, source, fallback):
+        # type: (FSPath, WheelSource, Scheme) -> Scheme
+        data_dir = source.data_dir
+
+        # If it's in not `{distribution}-{version}.data`, then it's in root_scheme.
+        if not posixpath.commonprefix([data_dir, path]) == data_dir:
+            return fallback
+
+        left, right = posixpath.split(path)
+        while left != data_dir:
+            left, right = posixpath.split(left)
+
+        scheme_name = right
+        if scheme_name not in Scheme.__members__:
+            msg_fmt = u"{path} is not contained in a valid .data subdirectory."
+            raise InvalidWheelSource(
+                source,
+                msg_fmt.format(path=path)
+            )
+
+        return Scheme.__members__[scheme_name]

--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -21,7 +21,7 @@ __all__ = ["Installer"]
 
 
 class Installer(object):
-    """Implements wheel installation logic
+    """Implements wheel installation logic.
 
     Supports Wheel version 1.0 (PEP 427).
     """
@@ -37,7 +37,7 @@ class Installer(object):
         """Install a wheel, as described by ``source``, to ``destination``.
         """
 
-        # Process the WHEEL file
+        # Process the WHEEL file.
         wheel_metadata_stream = source.open_dist_info(u"WHEEL")
         metadata = parse_metadata_file(wheel_metadata_stream)
 

--- a/src/installer/protocols.py
+++ b/src/installer/protocols.py
@@ -16,8 +16,8 @@ Scheme = Enum("Scheme", ["purelib", "platlib", "headers", "scripts", "data"])
 
 @with_metaclass(abc.ABCMeta)
 class WheelSource(object):
-    """Represents an installable wheel.
-    """
+    
+    """Represents an installable wheel."""
 
     def __init__(self, distribution, version):
         # type: (Text, Text) -> None
@@ -27,14 +27,12 @@ class WheelSource(object):
 
     @property
     def dist_info_dir(self):
-        """Name of the dist-info directory.
-        """
+        """Name of the dist-info directory."""
         return u"{}-{}.dist-info".format(self.distribution, self.version)
 
     @property
     def data_dir(self):
-        """Name of the data directory.
-        """
+        """Name of the data directory."""
         return u"{}-{}.data".format(self.distribution, self.version)
 
     @abc.abstractproperty

--- a/src/installer/protocols.py
+++ b/src/installer/protocols.py
@@ -1,0 +1,120 @@
+import abc
+from enum import Enum
+
+from installer._compat import with_metaclass
+from installer._compat.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from io import BufferedReader
+    from typing import List, Sequence, Tuple
+
+    from installer._compat.typing import Text, FSPath
+
+
+Scheme = Enum("Scheme", ["purelib", "platlib", "headers", "scripts", "data"])
+
+
+@with_metaclass(abc.ABCMeta)
+class WheelSource(object):
+    """Represents an installable wheel.
+    """
+
+    def __init__(self, distribution, version):
+        # type: (Text, Text) -> None
+        super(WheelSource, self).__init__()
+        self.distribution = distribution
+        self.version = version
+
+    @property
+    def dist_info_dir(self):
+        """Name of the dist-info directory.
+        """
+        return u"{}-{}.dist-info".format(self.distribution, self.version)
+
+    @property
+    def data_dir(self):
+        """Name of the data directory.
+        """
+        return u"{}-{}.data".format(self.distribution, self.version)
+
+    @abc.abstractproperty
+    def dist_info_filenames(self):
+        # type: () -> List[FSPath]
+        """Get names of all files in the dist-info directory.
+
+        Sample usage/behavior::
+
+            >>> wheel_source.dist_info_filenames
+            ["INSTALLER", "METADATA", "WHEEL"]
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def open_dist_info(self, filename):
+        # type: (FSPath) -> BufferedReader
+        """Get readable stream of data, from ``filename`` in the dist-info directory.
+
+        Sample usage/behavior::
+
+            >>> f = wheel_source.open_dist_info("INSTALLER")
+            >>> f.read()
+            'pip'
+        """
+        raise NotImplementedError()
+
+    # All files in the wheel
+    @abc.abstractmethod
+    def iter_files(self):
+        # type: () -> Iterator[Tuple[FSPath, BufferedReader]]
+        """Sequential access to all contents of the wheel (including dist-info files).
+
+        All paths must be posix-style paths (i.e. can be used with ``posixpath`` module)
+        relative to the root of the wheel.
+
+        Sample usage/behavior::
+
+            >>> iterable = wheel_source.iter_files()
+            >>> next(iterable)
+            ('pkg-1.0.0.dist-info/METADATA', <...>)
+
+        This method may be called multiple times, and each iterator returned must
+        provide the same content upon reading from the streams.
+        """
+        raise NotImplementedError()
+
+
+@with_metaclass(abc.ABCMeta)
+class Destination(object):
+    """Represents the location for installation.
+
+    Subclasses are expected to handle script generation and rewriting of the
+    RECORD file after installation.
+    """
+
+    @abc.abstractmethod
+    def write_file(self, scheme, path, stream):
+        # type: (Scheme, FSPath, BufferedReader) -> None
+        """TODO: write a good one line description of this function.
+
+        Example usage/behavior::
+
+            >>> stream = open("__init__.py")
+            >>> dest.write_file(Scheme.purelib, "__init__.py", stream)
+
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def rewrite_record(self, scheme):
+        # type: (Scheme) -> None
+        """Rewrite RECORD, using information already provided via ``write_file`` calls.
+
+        Example usage/behavior::
+
+            >>> dest.write_file(Scheme.purelib, "__init__.py", stream1)
+            >>> dest.write_file(Scheme.purelib, "awesome_wrapper.py", stream2)
+            >>> dest.write_file(Scheme.purelib, "_awesome.pyd", stream3)
+            >>> dest.rewrite_record(Scheme.purelib)
+
+        """
+        raise NotImplementedError()

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -37,8 +37,8 @@ def parse_metadata_file(contents):
 # RECORD file parsing
 #
 class InvalidRecord(Exception):
-    """Raised when a Record is not valid, due to improper element values or count.
-    """
+
+    """Raised when a Record is not valid, due to improper element values or count."""
 
     def __init__(self, elements, issues):
         super(InvalidRecord, self).__init__(", ".join(issues))
@@ -145,8 +145,7 @@ class Record(object):
 
 def parse_record_file(rows):
     # type: (Iterator[str]) -> Iterator[Record]
-    """Parse a RECORD file, provided as an iterator of record lines.
-    """
+    """Parse a RECORD file, provided as an iterator of record lines."""
     reader = csv.reader(rows, delimiter=",", quotechar='"', lineterminator=os.linesep)
     for row_index, elements in enumerate(reader):
         if len(elements) != 3:

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -5,22 +5,37 @@ import base64
 import csv
 import hashlib
 import os
+from email.parser import FeedParser
 
 from installer._compat.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from email.message import Message
     from typing import Iterator, Optional
     from installer._compat.typing import FSPath
 
-
 __all__ = [
-    "Hash",
-    "Record",
-    "InvalidRecord",
-    "parse_record_file",
+    "parse_metadata_file", "parse_record_file", "Hash", "Record", "InvalidRecord",
 ]
 
 
+#
+# METADATA (and WHEEL) file parsing
+#
+def parse_metadata_file(contents):
+    # type: (Text) -> Message
+    """Parse a METADATA / WHEEL / PKG-INFO file.
+
+    :param contents: The entire contents of the file.
+    """
+    feed_parser = FeedParser()
+    feed_parser.feed(contents)
+    return feed_parser.close()
+
+
+#
+# RECORD file parsing
+#
 class InvalidRecord(Exception):
     """Raised when a Record is not valid, due to improper element values or count.
     """

--- a/src/installer/validation.py
+++ b/src/installer/validation.py
@@ -1,0 +1,26 @@
+"""Validation checks for wheel files.
+"""
+
+
+class InvalidWheelSource(Exception):
+    """Raised when a ``WheelSource`` is not valid.
+    """
+
+    def __init__(self, source, reason):
+        super(InvalidWheelSource, self).__init__(source, reason)
+        self.source = source
+        self.reason = reason
+
+    @classmethod
+    def from_multiple(cls, source, exceptions):
+        # type: (WheelSource, Iterable[InvalidWheelSource])
+        reason = ", ".join(e.reason for e in exceptions)
+        return cls(source=source, reason=reason)
+
+
+#
+# Basic Validators
+#
+def validate_contents_match_RECORD_file(source):
+    # TODO: implement this, after #9 is merged.
+    pass


### PR DESCRIPTION
Built on top of #12 

Filing early to get inputs on this design / approach. As of right now, the design has 4 interacting components: the `Installer` class encapsulates all the installation logic, interacts with all the other abstractions and is the main entry point. `WheelSource` and `Destination`, which do exactly what their name suggests. And, finally, there's the coolest kids on the block, `Validator`s.

`WheelSource` represents a wheel file (like a .whl file on disk). It provides random access to dist-info files, and sequential access to *all* the files within the wheel. This lets `Installer` read the metadata files it needs (only WHEEL), any potential validators to read other metadata (like RECORD files), while making it straightforward to consume the contents of the wheel.

`Destination` handles all the file-writing stuff (so all the I/O) and has the job of rewriting the RECORD file appropriately.

`Validator`s are... `Callable[[WheelSource], None]` which can raise an error to signal not-valid. That's it.

---

One of the quirks of this approach/design, is that we don't actually "unpack" the wheel root into the corresponding scheme, but instead figure out the correct place to put the files the moment we see them. This lets us simplify the Destination API, and avoids an extra step (potentially reducing I/O operations).

---

Two things that I am wondering:

- Maybe we should have some way to preserve `stat(...).st_mtime` from `WheelSource` to `Destination`?
- Is there a better abstraction to pass around than BufferedReader?
