### PR TITLE
Add initial "source" and "destination" abstractions

### DIFF
--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -1,0 +1,45 @@
+"""Handles all file writing and post-installation processing."""
+
+from installer._compat.typing import TYPE_CHECKING
+from installer.records import Record
+
+if TYPE_CHECKING:
+    from typing import BinaryIO, Iterable
+
+    from installer._compat.typing import FSPath
+    from installer.utils import Scheme
+
+
+class WheelDestination(object):
+    """Represents the location for wheel installation.
+
+    Subclasses are expected to handle script generation and rewriting of the
+    RECORD file after installation.
+    """
+
+    def write_file(self, scheme, path, stream):
+        # type: (Scheme, FSPath, BinaryIO) -> Record
+        """TODO: write a good one line description of this function.
+
+        Example usage/behaviour::
+
+            >>> stream = open("__init__.py")
+            >>> dest.write_file("purelib", "pkg/__init__.py", stream)
+
+        """
+        raise NotImplementedError
+
+    def finalize_installation(self, scheme, records):
+        # type: (Scheme, Iterable[Record]) -> None
+        """Finalize installation, after all the files are written.
+
+        This method is required to (re)write the RECORD file such that it includes
+        all given ``records`` as well as any additional generated content (eg: scripts).
+
+        Example usage/behaviour::
+
+            >>> dest.finalize_installation("purelib")
+            ...
+
+        """
+        raise NotImplementedError

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -1,0 +1,88 @@
+"""Source of information about a wheel file."""
+
+from installer._compat.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import BinaryIO, Iterator, List, Tuple
+
+    from installer._compat.typing import FSPath, Text
+
+    WheelContentElement = Tuple[Tuple[FSPath, str, str], BinaryIO]
+
+
+class WheelSource(object):
+    """Represents an installable wheel.
+
+    This is an abstract class, whose methods have to be implemented by subclasses.
+    """
+
+    def __init__(self, distribution, version):
+        # type: (Text, Text) -> None
+        """Initialize a WheelSource object.
+
+        :param distribution: distribution name (like ``urllib3``)
+        :param version: version associated with the wheel
+        """
+        super(WheelSource, self).__init__()
+        self.distribution = distribution
+        self.version = version
+
+    @property
+    def dist_info_dir(self):
+        """Name of the dist-info directory."""
+        return "{}-{}.dist-info".format(self.distribution, self.version)
+
+    @property
+    def data_dir(self):
+        """Name of the data directory."""
+        return "{}-{}.data".format(self.distribution, self.version)
+
+    @property
+    def dist_info_filenames(self):
+        # type: () -> List[FSPath]
+        """Get names of all files in the dist-info directory.
+
+        Sample usage/behaviour::
+
+            >>> wheel_source.dist_info_filenames
+            ['METADATA', 'WHEEL']
+        """
+        raise NotImplementedError
+
+    def read_dist_info(self, filename):
+        # type: (FSPath) -> Text
+        """Get contents, from ``filename`` in the dist-info directory.
+
+        Sample usage/behaviour::
+
+            >>> wheel_source.read_dist_info("METADATA")
+            ...
+
+        :param filename: name of the file
+        """
+        raise NotImplementedError
+
+    def get_contents(self):
+        # type: () -> Iterator[WheelContentElement]
+        """Sequential access to all contents of the wheel (including dist-info files).
+
+        This method should return an iterable. Each value from the iterable must be a
+        tuple containing 2 elements:
+
+        - record: 3-value tuple, to pass to
+          :py:meth:`Record.from_elements <installer.records.Record.from_elements>`.
+        - stream: An :py:class:`io.BufferedReader` object, providing the contents of the
+          file at the location provided by the first element (path).
+
+        All paths must be relative to the root of the wheel.
+
+        Sample usage/behaviour::
+
+            >>> iterable = wheel_source.get_contents()
+            >>> next(iterable)
+            (('pkg/__init__.py', '', '0'), <...>)
+
+        This method may be called multiple times. Each iterable returned must
+        provide the same content upon reading from a specific file's stream.
+        """
+        raise NotImplementedError

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -1,0 +1,17 @@
+import pytest
+
+from installer.destinations import WheelDestination
+
+
+class TestWheelDestination:
+    def test_takes_no_arguments(self):
+        WheelDestination()
+
+    def test_raises_not_implemented_error(self):
+        destination = WheelDestination()
+
+        with pytest.raises(NotImplementedError):
+            destination.write_file(scheme=None, path=None, stream=None)
+
+        with pytest.raises(NotImplementedError):
+            destination.finalize_installation(scheme=None, records=None)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,27 @@
+import pytest
+
+from installer.sources import WheelSource
+
+
+class TestWheelSource:
+    def test_takes_two_arguments(self):
+        WheelSource("distribution", "version")
+        WheelSource(distribution="distribution", version="version")
+
+    def test_correctly_computes_properties(self):
+        source = WheelSource(distribution="distribution", version="version")
+
+        assert source.data_dir == "distribution-version.data"
+        assert source.dist_info_dir == "distribution-version.dist-info"
+
+    def test_raises_not_implemented_error(self):
+        source = WheelSource(distribution="distribution", version="version")
+
+        with pytest.raises(NotImplementedError):
+            source.dist_info_filenames
+
+        with pytest.raises(NotImplementedError):
+            source.read_dist_info("METADATA")
+
+        with pytest.raises(NotImplementedError):
+            source.get_contents()


### PR DESCRIPTION
A couple of rough design notes:

- The `WheelSource` is intentionally not tied to any properties within this package -- this allows other projects (such as `wheel`) to implement this interface without needing to add a dependency.
- The `WheelDestination` is where nearly all of the logical "nuance" of script generation and RECORD writing lives. This is an intentional choice. This allows for the "core" to only need to know how the wheel file is structured, and correctly invoke this class.

This is NOT "the final API" -- the plan/expectation is that there would likely be more iterations on this as we get feedback on how this works when trying implementing this interface; as the "core" is implemented and as the concrete implementations for these are written. And, yes, there's also gonna be actual useful concrete implementations of these abstractions, that'll live right next to them. Those are what I'd expect normal humans to use.

But one thing at a time. :)