### PR TITLE
Fix documentation's opening example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,12 +41,12 @@ import sys
 import sysconfig
 
 from installer import install
-from installer.destinations import SchemeDictDestination
+from installer.destinations import SchemeDictionaryDestination
 from installer.sources import WheelFile
 
 # Handler for installation directories and writing into them.
-destination = SchemeDictDestination(
-    sysconfig.get_config_vars(),
+destination = SchemeDictionaryDestination(
+    sysconfig.get_paths(),
     interpreter=sys.executable,
     script_kind="posix",
 )


### PR DESCRIPTION
Use a script that has been tested locally, to make sure that it works.