### PR TITLE
Fix entrypoints management

### DIFF
--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -85,8 +85,8 @@ def install(source, destination, additional_metadata):
     written_records = []
 
     # Write the entry-points based scripts.
-    if "entry-points.txt" in source.dist_info_filenames:
-        entrypoints_text = source.read_dist_info("entry-points.txt")
+    if "entry_points.txt" in source.dist_info_filenames:
+        entrypoints_text = source.read_dist_info("entry_points.txt")
         for name, module, attr, section in parse_entrypoints(entrypoints_text):
             record = destination.write_script(
                 name=name,

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -170,7 +170,14 @@ class SchemeDictionaryDestination(WheelDestination):
         script_name, data = script.generate(self.interpreter, self.script_kind)
 
         with io.BytesIO(data) as stream:
-            return self.write_to_fs(Scheme("scripts"), script_name, stream)
+            entry = self.write_to_fs(Scheme("scripts"), script_name, stream)
+
+            path = os.path.join(self.scheme_dict[Scheme("scripts")], script_name)
+            mode = os.stat(path).st_mode
+            mode |= (mode & 0o444) >> 2
+            os.chmod(path, mode)
+
+            return entry
 
     def finalize_installation(self, scheme, record_file_path, records):
         # type: (Scheme, FSPath, Iterable[RecordEntry]) -> None

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -190,6 +190,9 @@ def parse_entrypoints(text):
 
     # Borrowed from https://github.com/python/importlib_metadata/blob/v3.4.0/importlib_metadata/__init__.py#L90  # noqa
     for section in config.sections():
+        if section not in ["console_scripts", "gui_scripts"]:
+            continue
+
         for name, value in config.items(section):
             assert isinstance(name, Text)
             match = _ENTRYPOINT_REGEX.match(value)
@@ -204,6 +207,5 @@ def parse_entrypoints(text):
             assert isinstance(attrs, Text)
 
             script_section = cast("ScriptSection", section[: -len("_scripts")])
-            assert script_section in ["gui", "console"]
 
             yield name, module, attrs, script_section

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -188,7 +188,6 @@ def parse_entrypoints(text):
     config.optionxform = Text  # type: ignore
     config.read_string(text)
 
-    # Borrowed from https://github.com/python/importlib_metadata/blob/v3.4.0/importlib_metadata/__init__.py#L90  # noqa
     for section in config.sections():
         if section not in ["console_scripts", "gui_scripts"]:
             continue

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,7 +116,7 @@ class TestInstall:
                 "top_level.txt": b"""\
                     fancy
                 """,
-                "entry-points.txt": b"""\
+                "entry_points.txt": b"""\
                     [console_scripts]
                     fancy = fancy:main
 
@@ -188,7 +188,7 @@ class TestInstall:
                 ),
                 mock.call.write_file(
                     scheme="purelib",
-                    path="fancy-1.0.0.dist-info/entry-points.txt",
+                    path="fancy-1.0.0.dist-info/entry_points.txt",
                     stream=mock.ANY,
                 ),
                 mock.call.write_file(
@@ -211,7 +211,7 @@ class TestInstall:
                         ("fancy/__main__.py", "purelib", 0),
                         ("fancy-1.0.0.dist-info/METADATA", "purelib", 0),
                         ("fancy-1.0.0.dist-info/WHEEL", "purelib", 0),
-                        ("fancy-1.0.0.dist-info/entry-points.txt", "purelib", 0),
+                        ("fancy-1.0.0.dist-info/entry_points.txt", "purelib", 0),
                         ("fancy-1.0.0.dist-info/top_level.txt", "purelib", 0),
                         ("fancy-1.0.0.dist-info/fun_file.txt", "purelib", 0),
                         RecordEntry("fancy-1.0.0.dist-info/RECORD", None, None),
@@ -337,7 +337,7 @@ class TestInstall:
                 "top_level.txt": b"""\
                     fancy
                 """,
-                "entry-points.txt": b"""\
+                "entry_points.txt": b"""\
                     [console_scripts]
                     fancy = fancy:main
 
@@ -409,7 +409,7 @@ class TestInstall:
                 ),
                 mock.call.write_file(
                     scheme="platlib",
-                    path="fancy-1.0.0.dist-info/entry-points.txt",
+                    path="fancy-1.0.0.dist-info/entry_points.txt",
                     stream=mock.ANY,
                 ),
                 mock.call.write_file(
@@ -432,7 +432,7 @@ class TestInstall:
                         ("fancy/__main__.py", "platlib", 0),
                         ("fancy-1.0.0.dist-info/METADATA", "platlib", 0),
                         ("fancy-1.0.0.dist-info/WHEEL", "platlib", 0),
-                        ("fancy-1.0.0.dist-info/entry-points.txt", "platlib", 0),
+                        ("fancy-1.0.0.dist-info/entry_points.txt", "platlib", 0),
                         ("fancy-1.0.0.dist-info/top_level.txt", "platlib", 0),
                         ("fancy-1.0.0.dist-info/fun_file.txt", "platlib", 0),
                         RecordEntry("fancy-1.0.0.dist-info/RECORD", None, None),
@@ -461,7 +461,7 @@ class TestInstall:
                 "top_level.txt": b"""\
                     fancy
                 """,
-                "entry-points.txt": b"""\
+                "entry_points.txt": b"""\
                     [console_scripts]
                     fancy = fancy:main
 
@@ -521,7 +521,7 @@ class TestInstall:
                 "top_level.txt": b"""\
                     fancy
                 """,
-                "entry-points.txt": b"""\
+                "entry_points.txt": b"""\
                     [console_scripts]
                     fancy = fancy:main
 
@@ -589,7 +589,7 @@ class TestInstall:
                 "top_level.txt": b"""\
                     fancy
                 """,
-                "entry-points.txt": b"""\
+                "entry_points.txt": b"""\
                     [console_scripts]
                     fancy = fancy:main
 
@@ -679,7 +679,7 @@ class TestInstall:
                 ),
                 mock.call.write_file(
                     scheme="purelib",
-                    path="fancy-1.0.0.dist-info/entry-points.txt",
+                    path="fancy-1.0.0.dist-info/entry_points.txt",
                     stream=mock.ANY,
                 ),
                 mock.call.write_file(
@@ -701,7 +701,7 @@ class TestInstall:
                         ("fancy/__init__.py", "purelib", 0),
                         ("fancy-1.0.0.dist-info/METADATA", "purelib", 0),
                         ("fancy-1.0.0.dist-info/WHEEL", "purelib", 0),
-                        ("fancy-1.0.0.dist-info/entry-points.txt", "purelib", 0),
+                        ("fancy-1.0.0.dist-info/entry_points.txt", "purelib", 0),
                         ("fancy-1.0.0.dist-info/top_level.txt", "purelib", 0),
                         RecordEntry("fancy-1.0.0.dist-info/RECORD", None, None),
                     ],
@@ -729,7 +729,7 @@ class TestInstall:
                 "top_level.txt": b"""\
                     fancy
                 """,
-                "entry-points.txt": b"""\
+                "entry_points.txt": b"""\
                     [console_scripts]
                     fancy = fancy:main
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,6 +175,13 @@ class TestParseEntryPoints:
             (u"", []),
             (
                 u"""
+                    [foo]
+                    foo = foo.bar
+                """,
+                [],
+            ),
+            (
+                u"""
                     [console_scripts]
                     package = package.__main__:package
                 """,


### PR DESCRIPTION
I am currently trying to integrate `installer` into Poetry and things are mostly good but there were issues with how the entrypoints were managed. More specifically:

- The entry points file was not properly detected (`installer` was looking for a `entry-points.txt` file while the actual file is `entry_points.txt`).
- Assertion errors were raised for some entry points (either because they did not match the regexp or were missing the attribute part, which is not required for non-script entry points). This was fixed by ensuring that the `parse_entrypoints()` function only parses script entry points.
- Finally, generated scripts were not executable.