### PR TITLE
Fix KeyError when getting wheels contents

### DIFF
--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -162,7 +162,7 @@ class WheelFile(WheelSource):
         record_mapping = {record[0]: record for record in records}
 
         for item in self._zipfile.infolist():
-            record = record_mapping.pop(item.filename)
+            record = record_mapping.pop(item.filename, None)
             assert record is not None, "In {}, {} is not mentioned in RECORD".format(
                 self._zipfile.filename,
                 item.filename,


### PR DESCRIPTION
The `default` argument of [`dict.pop`](https://docs.python.org/3/library/stdtypes.html#dict.pop) was missing.
We could otherwise catch the KeyError and reraise a ValueError or something. Let me know.

Fixes #69