### PR TITLE
Preserve the executable bit from wheel contents

### DIFF
--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -93,7 +93,7 @@ def install(
             written_records.append((Scheme("scripts"), record))
 
     # Write all the files from the wheel.
-    for record_elements, stream in source.get_contents():
+    for record_elements, stream, is_executable in source.get_contents():
         source_record = RecordEntry.from_elements(*record_elements)
         path = source_record.path
         # Skip the RECORD, which is written at the end, based on this info.
@@ -110,6 +110,7 @@ def install(
             scheme=scheme,
             path=destination_path,
             stream=stream,
+            is_executable=is_executable,
         )
         written_records.append((scheme, record))
 
@@ -122,6 +123,7 @@ def install(
                 scheme=root_scheme,
                 path=path,
                 stream=other_stream,
+                is_executable=is_executable,
             )
         written_records.append((root_scheme, record))
 

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -11,6 +11,7 @@ from installer.utils import (
     construct_record_file,
     copyfileobj_with_hashing,
     fix_shebang,
+    make_file_executable,
 )
 
 if TYPE_CHECKING:
@@ -44,13 +45,18 @@ class WheelDestination:
         raise NotImplementedError
 
     def write_file(
-        self, scheme: Scheme, path: Union[str, "os.PathLike[str]"], stream: BinaryIO
+        self,
+        scheme: Scheme,
+        path: Union[str, "os.PathLike[str]"],
+        stream: BinaryIO,
+        is_executable: bool,
     ) -> RecordEntry:
         """Write a file to correct ``path`` within the ``scheme``.
 
         :param scheme: scheme to write the file in (like "purelib", "platlib" etc).
         :param path: path within that scheme
         :param stream: contents of the file
+        :param is_executable: whether the file should be made executable
 
         The stream would be closed by the caller, after this call.
 
@@ -108,12 +114,19 @@ class SchemeDictionaryDestination(WheelDestination):
         self.script_kind = script_kind
         self.hash_algorithm = hash_algorithm
 
-    def write_to_fs(self, scheme: Scheme, path: str, stream: BinaryIO) -> RecordEntry:
+    def write_to_fs(
+        self,
+        scheme: Scheme,
+        path: str,
+        stream: BinaryIO,
+        is_executable: bool,
+    ) -> RecordEntry:
         """Write contents of ``stream`` to the correct location on the filesystem.
 
         :param scheme: scheme to write the file in (like "purelib", "platlib" etc).
         :param path: path within that scheme
         :param stream: contents of the file
+        :param is_executable: whether the file should be made executable
 
         - Ensures that an existing file is not being overwritten.
         - Hashes the written content, to determine the entry in the ``RECORD`` file.
@@ -130,16 +143,24 @@ class SchemeDictionaryDestination(WheelDestination):
         with open(target_path, "wb") as f:
             hash_, size = copyfileobj_with_hashing(stream, f, self.hash_algorithm)
 
+        if is_executable:
+            make_file_executable(target_path)
+
         return RecordEntry(path, Hash(self.hash_algorithm, hash_), size)
 
     def write_file(
-        self, scheme: Scheme, path: Union[str, "os.PathLike[str]"], stream: BinaryIO
+        self,
+        scheme: Scheme,
+        path: Union[str, "os.PathLike[str]"],
+        stream: BinaryIO,
+        is_executable: bool,
     ) -> RecordEntry:
         """Write a file to correct ``path`` within the ``scheme``.
 
         :param scheme: scheme to write the file in (like "purelib", "platlib" etc).
         :param path: path within that scheme
         :param stream: contents of the file
+        :param is_executable: whether the file should be made executable
 
         - Changes the shebang for files in the "scripts" scheme.
         - Uses :py:meth:`SchemeDictionaryDestination.write_to_fs` for the
@@ -149,9 +170,11 @@ class SchemeDictionaryDestination(WheelDestination):
 
         if scheme == "scripts":
             with fix_shebang(stream, self.interpreter) as stream_with_different_shebang:
-                return self.write_to_fs(scheme, path_, stream_with_different_shebang)
+                return self.write_to_fs(
+                    scheme, path_, stream_with_different_shebang, is_executable
+                )
 
-        return self.write_to_fs(scheme, path_, stream)
+        return self.write_to_fs(scheme, path_, stream, is_executable)
 
     def write_script(
         self, name: str, module: str, attr: str, section: "ScriptSection"
@@ -174,7 +197,9 @@ class SchemeDictionaryDestination(WheelDestination):
         script_name, data = script.generate(self.interpreter, self.script_kind)
 
         with io.BytesIO(data) as stream:
-            entry = self.write_to_fs(Scheme("scripts"), script_name, stream)
+            entry = self.write_to_fs(
+                Scheme("scripts"), script_name, stream, is_executable=True
+            )
 
             path = os.path.join(self.scheme_dict[Scheme("scripts")], script_name)
             mode = os.stat(path).st_mode
@@ -206,4 +231,6 @@ class SchemeDictionaryDestination(WheelDestination):
             return path + "/"
 
         with construct_record_file(records, prefix_for_scheme) as record_stream:
-            self.write_to_fs(scheme, record_file_path, record_stream)
+            self.write_to_fs(
+                scheme, record_file_path, record_stream, is_executable=False
+            )

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -19,6 +19,7 @@ from typing import (
     NewType,
     Optional,
     Tuple,
+    Union,
     cast,
 )
 
@@ -38,6 +39,7 @@ __all__ = [
     "fix_shebang",
     "construct_record_file",
     "parse_entrypoints",
+    "make_file_executable",
     "WheelFilename",
     "SCHEME_NAMES",
 ]
@@ -229,3 +231,17 @@ def parse_entrypoints(text: str) -> Iterable[Tuple[str, str, str, "ScriptSection
             script_section = cast("ScriptSection", section[: -len("_scripts")])
 
             yield name, module, attrs, script_section
+
+
+def _current_umask() -> int:
+    """Get the current umask which involves having to set it temporarily."""
+    mask = os.umask(0)
+    os.umask(mask)
+    return mask
+
+
+# Borrowed from:
+# https://github.com/pypa/pip/blob/0f21fb92/src/pip/_internal/utils/unpacking.py#L93
+def make_file_executable(path: Union[str, "os.PathLike[str]"]) -> None:
+    """Make the file at the provided path executable."""
+    os.chmod(path, (0o777 & ~_current_umask() | 0o111))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,8 +23,9 @@ def mock_destination():
     retval = mock.Mock()
 
     # A hacky approach to making sure we got the right objects going in.
-    def custom_write_file(scheme, path, stream):
+    def custom_write_file(scheme, path, stream, is_executable):
         assert isinstance(stream, BytesIO)
+        assert is_executable is False
         return (path, scheme, 0)
 
     def custom_write_script(name, module, attr, section):
@@ -50,7 +51,7 @@ class FakeWheelSource(WheelSource):
         }
 
         # Compute RECORD file.
-        _records = [record for record, _ in self.get_contents()]
+        _records = [record for record, _, _ in self.get_contents()]
         self.dist_info_files["RECORD"] = "\n".join(
             sorted(
                 ",".join([file, "sha256=" + hash_, str(size)])
@@ -72,7 +73,7 @@ class FakeWheelSource(WheelSource):
             hashed, size = hash_and_size(content)
             record = (file, f"sha256={hashed}", str(size))
             with BytesIO(content) as stream:
-                yield record, stream
+                yield record, stream, False
 
         # Sort for deterministic behaviour for Python versions that do not preserve
         # insertion order for dictionaries.
@@ -85,7 +86,7 @@ class FakeWheelSource(WheelSource):
                 str(size),
             )
             with BytesIO(content) as stream:
-                yield record, stream
+                yield record, stream, False
 
 
 # --------------------------------------------------------------------------------------
@@ -166,36 +167,43 @@ class TestInstall:
                     scheme="purelib",
                     path="fancy/__init__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy/__main__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/METADATA",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/WHEEL",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/entry_points.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/top_level.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/fun_file.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.finalize_installation(
                     scheme="purelib",
@@ -283,31 +291,37 @@ class TestInstall:
                     scheme="purelib",
                     path="fancy/__init__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy/__main__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/METADATA",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/WHEEL",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/top_level.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/fun_file.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.finalize_installation(
                     scheme="purelib",
@@ -408,36 +422,43 @@ class TestInstall:
                     scheme="platlib",
                     path="fancy/__init__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy/__main__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy-1.0.0.dist-info/METADATA",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy-1.0.0.dist-info/WHEEL",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy-1.0.0.dist-info/entry_points.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy-1.0.0.dist-info/top_level.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy-1.0.0.dist-info/fun_file.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.finalize_installation(
                     scheme="platlib",
@@ -670,51 +691,61 @@ class TestInstall:
                     scheme="data",
                     path="fancy/data.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="headers",
                     path="fancy/headers.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="platlib",
                     path="fancy/platlib.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy/purelib.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="scripts",
                     path="fancy/scripts.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy/__init__.py",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/METADATA",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/WHEEL",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/entry_points.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.write_file(
                     scheme="purelib",
                     path="fancy-1.0.0.dist-info/top_level.txt",
                     stream=mock.ANY,
+                    is_executable=False,
                 ),
                 mock.call.finalize_installation(
                     scheme="purelib",

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -20,7 +20,9 @@ class TestWheelDestination:
             destination.write_script(name=None, module=None, attr=None, section=None)
 
         with pytest.raises(NotImplementedError):
-            destination.write_file(scheme=None, path=None, stream=None)
+            destination.write_file(
+                scheme=None, path=None, stream=None, is_executable=False
+            )
 
         with pytest.raises(NotImplementedError):
             destination.finalize_installation(
@@ -71,7 +73,7 @@ class TestSchemeDictionaryDestination:
         ],
     )
     def test_write_file(self, destination, scheme, path, data, expected):
-        record = destination.write_file(scheme, path, io.BytesIO(data))
+        record = destination.write_file(scheme, path, io.BytesIO(data), False)
         file_path = os.path.join(destination.scheme_dict[scheme], path)
         with open(file_path, "rb") as f:
             file_data = f.read()
@@ -80,9 +82,9 @@ class TestSchemeDictionaryDestination:
         assert record.path == path
 
     def test_write_record_duplicate(self, destination):
-        destination.write_file("data", "my_data.bin", io.BytesIO(b"my data")),
+        destination.write_file("data", "my_data.bin", io.BytesIO(b"my data"), False)
         with pytest.raises(FileExistsError):
-            destination.write_file("data", "my_data.bin", io.BytesIO(b"my data")),
+            destination.write_file("data", "my_data.bin", io.BytesIO(b"my data"), False)
 
     def test_write_script(self, destination):
         script_args = ("my_entrypoint", "my_module", "my_function", "console")
@@ -103,31 +105,46 @@ class TestSchemeDictionaryDestination:
             (
                 "data",
                 destination.write_file(
-                    "data", "my_data1.bin", io.BytesIO(b"my data 1")
+                    "data",
+                    "my_data1.bin",
+                    io.BytesIO(b"my data 1"),
+                    is_executable=False,
                 ),
             ),
             (
                 "data",
                 destination.write_file(
-                    "data", "my_data2.bin", io.BytesIO(b"my data 2")
+                    "data",
+                    "my_data2.bin",
+                    io.BytesIO(b"my data 2"),
+                    is_executable=False,
                 ),
             ),
             (
                 "data",
                 destination.write_file(
-                    "data", "my_data3.bin", io.BytesIO(b"my data 3")
+                    "data",
+                    "my_data3.bin",
+                    io.BytesIO(b"my data 3"),
+                    is_executable=False,
                 ),
             ),
             (
                 "scripts",
                 destination.write_file(
-                    "scripts", "my_script", io.BytesIO(b"my script")
+                    "scripts",
+                    "my_script",
+                    io.BytesIO(b"my script"),
+                    is_executable=True,
                 ),
             ),
             (
                 "scripts",
                 destination.write_file(
-                    "scripts", "my_script2", io.BytesIO(b"#!python\nmy script")
+                    "scripts",
+                    "my_script2",
+                    io.BytesIO(b"#!python\nmy script"),
+                    is_executable=False,
                 ),
             ),
             (

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -161,9 +161,10 @@ class TestWheelFile:
         got_records = []
         got_files = {}
         with WheelFile.open(fancy_wheel) as source:
-            for record_elements, stream in source.get_contents():
+            for record_elements, stream, is_executable in source.get_contents():
                 got_records.append(record_elements)
                 got_files[record_elements[0]] = stream.read()
+                assert not is_executable
 
         assert sorted(got_records) == sorted(expected_records)
         assert got_files == files


### PR DESCRIPTION
This is a property of individual files in the wheel, and thus needs to be parsed
by the `WheelSource`, and needs special handling in `WheelDestination`. It also
needs to be propagated through the entire pipeline, since the information needs
to be exchanged between the two components.

Closes #68 