### PR TITLE
Add simple, explicit CLI to install a .whl file

### DIFF
--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -1,3 +1,4 @@
+"""CLI - run as python -m installer"""
 import argparse
 
 from . import install
@@ -6,6 +7,7 @@ from .sources import WheelFile
 
 
 def main():
+    """Entry point for CLI"""
     ap = argparse.ArgumentParser("python -m installer")
     ap.add_argument("wheel_file", help="Path to a .whl file to install")
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -1,0 +1,60 @@
+import argparse
+
+from . import install
+from .destinations import SchemeDictionaryDestination
+from .sources import WheelFile
+
+def main():
+    ap = argparse.ArgumentParser("python -m installer")
+    ap.add_argument("wheel_file", help="Path to a .whl file to install")
+
+    ap.add_argument(
+        "--interpreter", required=True,
+        help="Interpreter path to be used in scripts"
+    )
+    ap.add_argument(
+        "--script-kind", required=True, choices=[
+            "posix", "win-ia32", "win-amd64", "win-arm", "win-arm64"
+        ], help="Kind of launcher to create for each script"
+    )
+
+    dest_args = ap.add_argument_group("Destination directories")
+    dest_args.add_argument(
+        '--purelib', required=True,
+        help="Directory for platform-independent Python modules"
+    )
+    dest_args.add_argument(
+        '--platlib', required=True,
+        help="Directory for platform-dependent Python modules"
+    )
+    dest_args.add_argument(
+        '--headers', required=True, help="Directory for C header files"
+    )
+    dest_args.add_argument(
+        '--scripts',  required=True, help="Directory for executable scripts"
+    )
+    dest_args.add_argument(
+        '--data', required=True, help="Directory for external data files"
+    )
+    args = ap.parse_args()
+
+    destination = SchemeDictionaryDestination({
+            'purelib': args.purelib,
+            'platlib': args.platlib,
+            'headers': args.headers,
+            'scripts': args.scripts,
+            'data': args.data,
+        },
+        interpreter=args.interpreter,
+        script_kind=args.script_kind,
+    )
+
+    with WheelFile.open(args.wheel_file) as source:
+        install(
+            source=source,
+            destination=destination,
+            additional_metadata={},
+        )
+
+if __name__ == '__main__':
+    main()

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -29,8 +29,8 @@ def main():
     )
     dest_args.add_argument(
         "--platlib",
-        required=True,
-        help="Directory for platform-dependent Python modules",
+        help="Directory for platform-dependent Python modules (same as purelib "
+        "if not specified)",
     )
     dest_args.add_argument(
         "--headers", required=True, help="Directory for C header files"
@@ -46,7 +46,7 @@ def main():
     destination = SchemeDictionaryDestination(
         {
             "purelib": args.purelib,
-            "platlib": args.platlib,
+            "platlib": args.platlib if args.platlib is not None else args.purelib,
             "headers": args.headers,
             "scripts": args.scripts,
             "data": args.data,

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -1,4 +1,4 @@
-"""CLI - run as python -m installer"""
+"""CLI - run as python -m installer."""
 import argparse
 
 from . import install
@@ -7,7 +7,7 @@ from .sources import WheelFile
 
 
 def main():
-    """Entry point for CLI"""
+    """Entry point for CLI."""
     ap = argparse.ArgumentParser("python -m installer")
     ap.add_argument("wheel_file", help="Path to a .whl file to install")
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -4,46 +4,50 @@ from . import install
 from .destinations import SchemeDictionaryDestination
 from .sources import WheelFile
 
+
 def main():
     ap = argparse.ArgumentParser("python -m installer")
     ap.add_argument("wheel_file", help="Path to a .whl file to install")
 
     ap.add_argument(
-        "--interpreter", required=True,
-        help="Interpreter path to be used in scripts"
+        "--interpreter", required=True, help="Interpreter path to be used in scripts"
     )
     ap.add_argument(
-        "--script-kind", required=True, choices=[
-            "posix", "win-ia32", "win-amd64", "win-arm", "win-arm64"
-        ], help="Kind of launcher to create for each script"
+        "--script-kind",
+        required=True,
+        choices=["posix", "win-ia32", "win-amd64", "win-arm", "win-arm64"],
+        help="Kind of launcher to create for each script",
     )
 
     dest_args = ap.add_argument_group("Destination directories")
     dest_args.add_argument(
-        '--purelib', required=True,
-        help="Directory for platform-independent Python modules"
+        "--purelib",
+        required=True,
+        help="Directory for platform-independent Python modules",
     )
     dest_args.add_argument(
-        '--platlib', required=True,
-        help="Directory for platform-dependent Python modules"
+        "--platlib",
+        required=True,
+        help="Directory for platform-dependent Python modules",
     )
     dest_args.add_argument(
-        '--headers', required=True, help="Directory for C header files"
+        "--headers", required=True, help="Directory for C header files"
     )
     dest_args.add_argument(
-        '--scripts',  required=True, help="Directory for executable scripts"
+        "--scripts", required=True, help="Directory for executable scripts"
     )
     dest_args.add_argument(
-        '--data', required=True, help="Directory for external data files"
+        "--data", required=True, help="Directory for external data files"
     )
     args = ap.parse_args()
 
-    destination = SchemeDictionaryDestination({
-            'purelib': args.purelib,
-            'platlib': args.platlib,
-            'headers': args.headers,
-            'scripts': args.scripts,
-            'data': args.data,
+    destination = SchemeDictionaryDestination(
+        {
+            "purelib": args.purelib,
+            "platlib": args.platlib,
+            "headers": args.headers,
+            "scripts": args.scripts,
+            "data": args.data,
         },
         interpreter=args.interpreter,
         script_kind=args.script_kind,
@@ -56,5 +60,6 @@ def main():
             additional_metadata={},
         )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
In the interests of moving the CLI question forwards, here's my take on a minimal CLI. That's minimal in the sense of a low-level interface to what `installer` can do, with no additional abstractions.

As a starting point, this requires that all the destination directories - purelib, platlib, headers, scripts, data - are specified explicitly as inputs. This would obviously be pretty verbose, but I think it's still useful, because downstream packaging is often built around shell commands, so even a long one is more convenient than embedding Python code to use the library. I also like that it makes the destination directories explicit, rather than downstreams finding ways to patch or hack around sysconfig or distutils to control where files end up.

But this is a starting point, and we could decide to add various convenience features:

- Make `--script-kind` optional and write POSIX launchers by default, which is probably what 90% of downstreams want, given the diverse packaging ecosystems on Linux especially.
- Make `--platlib` optional, use the same directory as `--purelib` by default
- Make `--headers` required only if the wheel contains a `foo-1.2.data/headers` directory (AFAIK this is either never or almost never used - the only thing I'm familiar with that ships headers is numpy, and it has them inside the package directory)
- Add a `--destdir` or `--root` option, for a path to prefix to all destination directories (#58). This is purely a convenience, because the caller can add the prefix themselves (`--purelib ${destdir}/path/to/site-packages` etc.), but maybe passing it 5 times is inconvenient enough to be worth a shortcut?
- Add an option - or an entirely separate entry point, like `python -m installer.thispython` - to do an installation for the Python & platform where installer is running (like pip, or the proposal in #66).