### PR TITLE
CLI to install to Python running installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,10 @@ home-page = "https://github.com/pradyunsg/installer"
 description-file = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.7"
+requires = [
+  "build >= 0.2.0",  # not a hard runtime requirement -- we can softfail
+  "packaging",  # not a hard runtime requirement -- we can softfail
+]
+
+[tool.flit.scripts]
+python-installer = "installer.__main__:entrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,3 @@ requires = [
   "build >= 0.2.0",  # not a hard runtime requirement -- we can softfail
   "packaging",  # not a hard runtime requirement -- we can softfail
 ]
-
-[tool.flit.scripts]
-python-installer = "installer.__main__:entrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,3 @@ home-page = "https://github.com/pradyunsg/installer"
 description-file = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.7"
-requires = [
-  "build >= 0.2.0",  # not a hard runtime requirement -- we can softfail
-  "packaging",  # not a hard runtime requirement -- we can softfail
-]

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -82,5 +82,5 @@ def main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
         installer.install(source, destination, {})
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main(sys.argv[1:], "python -m installer")

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -46,11 +46,8 @@ def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
 
     # calculate 'headers' path, not currently in sysconfig - see
     # https://bugs.python.org/issue44445. This is based on what distutils does.
-    # For new wheels, the name we get from the wheel filename should already
-    # be normalised (based on PEP 503, but with _ instead of -), but this is
-    # not the case for many existing wheels, so normalise it here.
-    normed_name = re.sub(r"[-_.]+", "_", distribution_name).lower()
-    scheme_dict["headers"] = os.path.join(scheme_dict["include"], normed_name)
+    # TODO: figure out original vs normalised names
+    scheme_dict["headers"] = os.path.join(scheme_dict["include"], distribution_name)
 
     return scheme_dict
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os.path
+import re
 import sys
 import sysconfig
 from typing import Dict, Optional, Sequence
@@ -43,9 +44,13 @@ def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
     """Calculate the scheme dictionary for the current Python environment."""
     scheme_dict = sysconfig.get_paths()
 
-    # calculate 'headers' path, not currently in sysconfig -
-    # see https://bugs.python.org/issue44445. This copies what distutils does.
-    scheme_dict["headers"] = os.path.join(scheme_dict["include"], distribution_name)
+    # calculate 'headers' path, not currently in sysconfig - see
+    # https://bugs.python.org/issue44445. This is based on what distutils does.
+    # For new wheels, the name we get from the wheel filename should already
+    # be normalised (based on PEP 503, but with _ instead of -), but this is
+    # not the case for many existing wheels, so normalise it here.
+    normed_name = re.sub(r"[-_.]+", "_", distribution_name).lower()
+    scheme_dict["headers"] = os.path.join(scheme_dict["include"], normed_name)
 
     return scheme_dict
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -157,9 +157,8 @@ def check_python_version(metadata: Message) -> None:
 def check_dependencies(metadata: Message) -> None:
     """Check if the project dependencies are met."""
     try:
-        import packaging  # noqa: F401
-
         import build
+        import packaging  # noqa: F401
     except ModuleNotFoundError as e:
         warnings.warn(f"'{e.name}' module not available, skipping dependency check")
         return

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os.path
-import re
 import sys
 import sysconfig
 from typing import Dict, Optional, Sequence

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -21,7 +21,6 @@ def main_parser() -> argparse.ArgumentParser:
         "-d",
         metavar="/",
         type=str,
-        default="/",
         help="destination directory (prefix to prepend to each file)",
     )
     parser.add_argument(

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -1,0 +1,211 @@
+"""Installer CLI."""
+
+import argparse
+import compileall
+import distutils.dist
+import pathlib
+import platform
+import sys
+import sysconfig
+import warnings
+from email.message import Message
+from typing import TYPE_CHECKING, Collection, Dict, Iterable, Optional, Sequence, Tuple
+
+import installer
+import installer.destinations
+import installer.sources
+import installer.utils
+from installer.records import RecordEntry
+from installer.utils import Scheme
+
+if TYPE_CHECKING:
+    from installer.scripts import LauncherKind
+
+
+class InstallerCompatibilityError(Exception):
+    """Error raised when the install target is not compatible with the environment."""
+
+
+class _MainDestination(installer.destinations.SchemeDictionaryDestination):
+    destdir: Optional[pathlib.Path]
+
+    def __init__(
+        self,
+        scheme_dict: Dict[str, str],
+        interpreter: str,
+        script_kind: "LauncherKind",
+        hash_algorithm: str = "sha256",
+        optimization_levels: Collection[int] = (0, 1),
+        destdir: Optional[str] = None,
+    ) -> None:
+        if destdir:
+            self.destdir = pathlib.Path(destdir).absolute()
+            self.destdir.mkdir(exist_ok=True, parents=True)
+            scheme_dict = {
+                name: self._destdir_path(value) for name, value in scheme_dict.items()
+            }
+        else:
+            self.destdir = None
+        super().__init__(scheme_dict, interpreter, script_kind, hash_algorithm)
+        self.optimization_levels = optimization_levels
+
+    def _destdir_path(self, file: str) -> str:
+        assert self.destdir
+        file_path = pathlib.Path(file)
+        rel_path = file_path.relative_to(file_path.anchor)
+        return str(self.destdir.joinpath(*rel_path.parts))
+
+    def _compile_record(self, scheme: Scheme, record: RecordEntry) -> None:
+        if scheme not in ("purelib", "platlib"):
+            return
+        for level in self.optimization_levels:
+            target_path = pathlib.Path(self.scheme_dict[scheme], record.path)
+            if sys.version_info < (3, 9):
+                compileall.compile_file(target_path, optimize=level)
+            else:
+                compileall.compile_file(
+                    target_path,
+                    optimize=level,
+                    stripdir=str(self.destdir),
+                )
+
+    def finalize_installation(
+        self,
+        scheme: Scheme,
+        record_file_path: str,
+        records: Iterable[Tuple[Scheme, RecordEntry]],
+    ) -> None:
+        record_list = list(records)
+        super().finalize_installation(scheme, record_file_path, record_list)
+        for scheme, record in record_list:
+            self._compile_record(scheme, record)
+
+
+def main_parser() -> argparse.ArgumentParser:
+    """Construct the main parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel", type=str, help="wheel file to install")
+    parser.add_argument(
+        "--destdir",
+        "-d",
+        metavar="/",
+        type=str,
+        default="/",
+        help="destination directory (prefix to prepend to each file)",
+    )
+    parser.add_argument(
+        "--optimize",
+        "-o",
+        nargs="*",
+        metavar="level",
+        type=int,
+        default=(0, 1),
+        help="generate bytecode for the specified optimization level(s) (default=0, 1)",
+    )
+    parser.add_argument(
+        "--skip-dependency-check",
+        "-s",
+        action="store_true",
+        help="don't check if the wheel dependencies are met",
+    )
+    return parser
+
+
+def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
+    """Calculate the scheme disctionary for the current Python environment."""
+    scheme_dict = sysconfig.get_paths()
+
+    # calculate 'headers' path, sysconfig does not have an equivalent
+    # see https://bugs.python.org/issue44445
+    dist_dict = {
+        "name": distribution_name,
+    }
+    distribution = distutils.dist.Distribution(dist_dict)
+    install_cmd = distribution.get_command_obj("install")
+    assert install_cmd
+    install_cmd.finalize_options()
+    # install_cmd.install_headers is not type hinted
+    scheme_dict["headers"] = install_cmd.install_headers  # type: ignore
+
+    return scheme_dict
+
+
+def check_python_version(metadata: Message) -> None:
+    """Check if the project support the current interpreter."""
+    try:
+        import packaging.specifiers
+    except ImportError:
+        warnings.warn(
+            "'packaging' module not available, "
+            "skipping python version compatibility check"
+        )
+        return
+
+    requirement = metadata["Requires-Python"]
+    if not requirement:
+        return
+
+    versions = requirement.split(",")
+    for version in versions:
+        specifier = packaging.specifiers.Specifier(version)
+        if platform.python_version() not in specifier:
+            raise InstallerCompatibilityError(
+                "Incompatible python version, needed: {}".format(version)
+            )
+
+
+def check_dependencies(metadata: Message) -> None:
+    """Check if the project dependencies are met."""
+    try:
+        import packaging  # noqa: F401
+
+        import build
+    except ModuleNotFoundError as e:
+        warnings.warn(f"'{e.name}' module not available, skipping dependency check")
+        return
+
+    missing = {
+        unmet
+        for requirement in metadata.get_all("Requires-Dist") or []
+        for unmet_list in build.check_dependency(requirement)
+        for unmet in unmet_list
+    }
+    if missing:
+        missing_list = ", ".join(missing)
+        raise InstallerCompatibilityError(
+            "Missing requirements: {}".format(missing_list)
+        )
+
+
+def main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
+    """Process arguments and perform the install."""
+    parser = main_parser()
+    if program:
+        parser.prog = program
+    args = parser.parse_args(cli_args)
+
+    with installer.sources.WheelFile.open(args.wheel) as source:
+        # compability checks
+        metadata_contents = source.read_dist_info("METADATA")
+        metadata = installer.utils.parse_metadata_file(metadata_contents)
+        check_python_version(metadata)
+        if not args.skip_dependency_check:
+            check_dependencies(metadata)
+
+        destination = _MainDestination(
+            get_scheme_dict(source.distribution),
+            sys.executable,
+            installer.utils.get_launcher_kind(),
+            optimization_levels=args.optimize,
+            destdir=args.destdir,
+        )
+        installer.install(source, destination, {})
+
+
+def entrypoint() -> None:
+    """CLI entrypoint."""
+    main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:], "python -m installer")

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -19,7 +19,7 @@ def main_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--destdir",
         "-d",
-        metavar="/",
+        metavar="path",
         type=str,
         help="destination directory (prefix to prepend to each file)",
     )

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -46,8 +46,13 @@ def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
 
     # calculate 'headers' path, not currently in sysconfig - see
     # https://bugs.python.org/issue44445. This is based on what distutils does.
-    # TODO: figure out original vs normalised names
-    scheme_dict["headers"] = os.path.join(scheme_dict["include"], distribution_name)
+    # TODO: figure out original vs normalised distribution names
+    scheme_dict["headers"] = os.path.join(
+        sysconfig.get_path(
+            "include", vars={"installed_base": sysconfig.get_config_var("base")}
+        ),
+        distribution_name,
+    )
 
     return scheme_dict
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -1,7 +1,7 @@
 """Installer CLI."""
 
 import argparse
-import distutils.dist
+import os.path
 import sys
 import sysconfig
 from typing import Dict, Optional, Sequence
@@ -43,17 +43,9 @@ def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
     """Calculate the scheme dictionary for the current Python environment."""
     scheme_dict = sysconfig.get_paths()
 
-    # calculate 'headers' path, sysconfig does not have an equivalent
-    # see https://bugs.python.org/issue44445
-    dist_dict = {
-        "name": distribution_name,
-    }
-    distribution = distutils.dist.Distribution(dist_dict)
-    install_cmd = distribution.get_command_obj("install")
-    assert install_cmd
-    install_cmd.finalize_options()
-    # install_cmd.install_headers is not type hinted
-    scheme_dict["headers"] = install_cmd.install_headers  # type: ignore
+    # calculate 'headers' path, not currently in sysconfig -
+    # see https://bugs.python.org/issue44445. This copies what distutils does.
+    scheme_dict["headers"] = os.path.join(scheme_dict["include"], distribution_name)
 
     return scheme_dict
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -40,7 +40,7 @@ def main_parser() -> argparse.ArgumentParser:
 
 
 def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
-    """Calculate the scheme disctionary for the current Python environment."""
+    """Calculate the scheme dictionary for the current Python environment."""
     scheme_dict = sysconfig.get_paths()
 
     # calculate 'headers' path, sysconfig does not have an equivalent

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -82,10 +82,5 @@ def main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
         installer.install(source, destination, {})
 
 
-def entrypoint() -> None:
-    """CLI entrypoint."""
-    main(sys.argv[1:])
-
-
 if __name__ == "__main__":
     main(sys.argv[1:], "python -m installer")

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -106,7 +106,7 @@ class SchemeDictionaryDestination(WheelDestination):
         interpreter: str,
         script_kind: "LauncherKind",
         hash_algorithm: str = "sha256",
-        bytecode_optimization_levels: Collection[int] = (0, 1),
+        bytecode_optimization_levels: Collection[int] = (),
         destdir: Optional[str] = None,
     ) -> None:
         """Construct a ``SchemeDictionaryDestination`` object.
@@ -118,7 +118,9 @@ class SchemeDictionaryDestination(WheelDestination):
             of :any:`hashlib.algorithms_available` (ideally from
             :any:`hashlib.algorithms_guaranteed`).
         :param bytecode_optimization_levels: Compile cached bytecode for
-            installed .py files with these optimization levels.
+            installed .py files with these optimization levels. The bytecode
+            is specific to the minor version of Python (e.g. 3.10) used to
+            generate it.
         :param destdir: A staging directory in which to write all files. This
             is expected to be the filesystem root at runtime, so embedded paths
             will be written as though this was the root.

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -213,7 +213,7 @@ class SchemeDictionaryDestination(WheelDestination):
             return entry
 
     def _compile_bytecode(self, scheme: Scheme, record: RecordEntry) -> None:
-        """Compile bytecode for a single .py file"""
+        """Compile bytecode for a single .py file."""
         if scheme not in ("purelib", "platlib"):
             return
 

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -3,11 +3,9 @@
 import compileall
 import io
 import os
-import sys
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Any,
     BinaryIO,
     Collection,
     Dict,
@@ -221,11 +219,13 @@ class SchemeDictionaryDestination(WheelDestination):
             return
 
         target_path = self._path_with_destdir(scheme, record.path)
+        dir_path_to_embed = os.path.dirname(  # Without destdir
+            os.path.join(self.scheme_dict[scheme], record.path)
+        )
         for level in self.bytecode_optimization_levels:
-            kwargs: Dict[str, Any] = {}
-            if sys.version_info >= (3, 9):  # pragma: no cover
-                kwargs["stripdir"] = str(self.destdir)
-            compileall.compile_file(target_path, optimize=level, quiet=1, **kwargs)
+            compileall.compile_file(
+                target_path, optimize=level, quiet=1, ddir=dir_path_to_embed
+            )
 
     def finalize_installation(
         self,

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     BinaryIO,
     Collection,
     Dict,
@@ -219,7 +220,7 @@ class SchemeDictionaryDestination(WheelDestination):
 
         target_path = self._destdir_path(scheme, record.path)
         for level in self.bytecode_optimization_levels:
-            kwargs = {}
+            kwargs: Dict[str, Any] = {}
             if sys.version_info >= (3, 9):  # pragma: no cover
                 kwargs["stripdir"] = str(self.destdir)
             compileall.compile_file(target_path, optimize=level, **kwargs)

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -132,7 +132,7 @@ class SchemeDictionaryDestination(WheelDestination):
         self.bytecode_optimization_levels = bytecode_optimization_levels
         self.destdir = destdir
 
-    def _destdir_path(self, scheme: Scheme, path: str) -> str:
+    def _path_with_destdir(self, scheme: Scheme, path: str) -> str:
         file = os.path.join(self.scheme_dict[scheme], path)
         if self.destdir is not None:
             file_path = Path(file)
@@ -150,7 +150,7 @@ class SchemeDictionaryDestination(WheelDestination):
         - Ensures that an existing file is not being overwritten.
         - Hashes the written content, to determine the entry in the ``RECORD`` file.
         """
-        target_path = self._destdir_path(scheme, path)
+        target_path = self._path_with_destdir(scheme, path)
         if os.path.exists(target_path):
             message = f"File already exists: {target_path}"
             raise FileExistsError(message)
@@ -208,7 +208,7 @@ class SchemeDictionaryDestination(WheelDestination):
         with io.BytesIO(data) as stream:
             entry = self.write_to_fs(Scheme("scripts"), script_name, stream)
 
-            path = self._destdir_path(Scheme("scripts"), script_name)
+            path = self._path_with_destdir(Scheme("scripts"), script_name)
             mode = os.stat(path).st_mode
             mode |= (mode & 0o444) >> 2
             os.chmod(path, mode)
@@ -220,7 +220,7 @@ class SchemeDictionaryDestination(WheelDestination):
         if scheme not in ("purelib", "platlib"):
             return
 
-        target_path = self._destdir_path(scheme, record.path)
+        target_path = self._path_with_destdir(scheme, record.path)
         for level in self.bytecode_optimization_levels:
             kwargs: Dict[str, Any] = {}
             if sys.version_info >= (3, 9):  # pragma: no cover

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -225,7 +225,7 @@ class SchemeDictionaryDestination(WheelDestination):
             kwargs: Dict[str, Any] = {}
             if sys.version_info >= (3, 9):  # pragma: no cover
                 kwargs["stripdir"] = str(self.destdir)
-            compileall.compile_file(target_path, optimize=level, **kwargs)
+            compileall.compile_file(target_path, optimize=level, quiet=1, **kwargs)
 
     def finalize_installation(
         self,

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -219,14 +219,10 @@ class SchemeDictionaryDestination(WheelDestination):
 
         target_path = self._destdir_path(scheme, record.path)
         for level in self.bytecode_optimization_levels:
-            if sys.version_info < (3, 9):
-                compileall.compile_file(target_path, optimize=level)
-            else:
-                compileall.compile_file(
-                    target_path,
-                    optimize=level,
-                    stripdir=str(self.destdir),
-                )
+            kwargs = {}
+            if sys.version_info >= (3, 9):  # pragma: no cover
+                kwargs['stripdir'] = str(self.destdir)
+            compileall.compile_file(target_path, optimize=level, **kwargs)
 
     def finalize_installation(
         self,

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -221,7 +221,7 @@ class SchemeDictionaryDestination(WheelDestination):
         for level in self.bytecode_optimization_levels:
             kwargs = {}
             if sys.version_info >= (3, 9):  # pragma: no cover
-                kwargs['stripdir'] = str(self.destdir)
+                kwargs["stripdir"] = str(self.destdir)
             compileall.compile_file(target_path, optimize=level, **kwargs)
 
     def finalize_installation(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import sys
 import textwrap
 import zipfile
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import zipfile
 
 import pytest
 
+
 @pytest.fixture
 def fancy_wheel(tmp_path):
     path = tmp_path / "fancy-1.0.0-py2.py3-none-any.whl"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,75 @@
+import sys
+import textwrap
+import zipfile
+
+import pytest
+
+@pytest.fixture
+def fancy_wheel(tmp_path):
+    path = tmp_path / "fancy-1.0.0-py2.py3-none-any.whl"
+    files = {
+        "fancy/": b"""""",
+        "fancy/__init__.py": b"""\
+            def main():
+                print("I'm fancy.")
+        """,
+        "fancy/__main__.py": b"""\
+            if __name__ == "__main__":
+                from . import main
+                main()
+        """,
+        "fancy-1.0.0.data/data/fancy/": b"""""",
+        "fancy-1.0.0.data/data/fancy/data.py": b"""\
+            # put me in data
+        """,
+        "fancy-1.0.0.dist-info/": b"""""",
+        "fancy-1.0.0.dist-info/top_level.txt": b"""\
+            fancy
+        """,
+        "fancy-1.0.0.dist-info/entry_points.txt": b"""\
+            [console_scripts]
+            fancy = fancy:main
+
+            [gui_scripts]
+            fancy-gui = fancy:main
+        """,
+        "fancy-1.0.0.dist-info/WHEEL": b"""\
+            Wheel-Version: 1.0
+            Generator: magic (1.0.0)
+            Root-Is-Purelib: true
+            Tag: py3-none-any
+        """,
+        "fancy-1.0.0.dist-info/METADATA": b"""\
+            Metadata-Version: 2.1
+            Name: fancy
+            Version: 1.0.0
+            Summary: A fancy package
+            Author: Agendaless Consulting
+            Author-email: nobody@example.com
+            License: MIT
+            Keywords: fancy amazing
+            Platform: UNKNOWN
+            Classifier: Intended Audience :: Developers
+        """,
+        # The RECORD file is indirectly validated by the WheelFile, since it only
+        # provides the items that are a part of the wheel.
+        "fancy-1.0.0.dist-info/RECORD": b"""\
+            fancy/__init__.py,,
+            fancy/__main__.py,,
+            fancy-1.0.0.data/data/fancy/data.py,,
+            fancy-1.0.0.dist-info/top_level.txt,,
+            fancy-1.0.0.dist-info/entry_points.txt,,
+            fancy-1.0.0.dist-info/WHEEL,,
+            fancy-1.0.0.dist-info/METADATA,,
+            fancy-1.0.0.dist-info/RECORD,,
+        """,
+    }
+
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, indented_content in files.items():
+            archive.writestr(
+                name,
+                textwrap.dedent(indented_content.decode("utf-8")).encode("utf-8"),
+            )
+
+    return path

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,32 +1,38 @@
 from installer.__main__ import get_scheme_dict, main
 
+
 def test_get_scheme_dict():
-    d = get_scheme_dict(distribution_name='foo')
-    assert set(d.keys()) >= {'purelib', 'platlib', 'headers', 'scripts', 'data'}
+    d = get_scheme_dict(distribution_name="foo")
+    assert set(d.keys()) >= {"purelib", "platlib", "headers", "scripts", "data"}
 
 
 def test_main(fancy_wheel, tmp_path):
-    destdir = tmp_path / 'dest'
+    destdir = tmp_path / "dest"
 
-    main([str(fancy_wheel), '-d', str(destdir)], "python -m installer")
+    main([str(fancy_wheel), "-d", str(destdir)], "python -m installer")
 
-    installed_py_files = destdir.rglob('*.py')
+    installed_py_files = destdir.rglob("*.py")
 
-    assert {f.stem for f in installed_py_files} == {'__init__', '__main__', 'data'}
+    assert {f.stem for f in installed_py_files} == {"__init__", "__main__", "data"}
 
-    installed_pyc_files = destdir.rglob('*.pyc')
-    assert {f.name.split('.')[0] for f in installed_pyc_files} == {
-        '__init__', '__main__'
+    installed_pyc_files = destdir.rglob("*.pyc")
+    assert {f.name.split(".")[0] for f in installed_pyc_files} == {
+        "__init__",
+        "__main__",
     }
 
+
 def test_main_no_pyc(fancy_wheel, tmp_path):
-    destdir = tmp_path / 'dest'
+    destdir = tmp_path / "dest"
 
-    main([str(fancy_wheel), '-d', str(destdir), '--no-compile-bytecode'], "python -m installer")
+    main(
+        [str(fancy_wheel), "-d", str(destdir), "--no-compile-bytecode"],
+        "python -m installer",
+    )
 
-    installed_py_files = destdir.rglob('*.py')
+    installed_py_files = destdir.rglob("*.py")
 
-    assert {f.stem for f in installed_py_files} == {'__init__', '__main__', 'data'}
+    assert {f.stem for f in installed_py_files} == {"__init__", "__main__", "data"}
 
-    installed_pyc_files = destdir.rglob('*.pyc')
+    installed_pyc_files = destdir.rglob("*.pyc")
     assert set(installed_pyc_files) == set()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,32 @@
+from installer.__main__ import get_scheme_dict, main
+
+def test_get_scheme_dict():
+    d = get_scheme_dict(distribution_name='foo')
+    assert set(d.keys()) >= {'purelib', 'platlib', 'headers', 'scripts', 'data'}
+
+
+def test_main(fancy_wheel, tmp_path):
+    destdir = tmp_path / 'dest'
+
+    main([str(fancy_wheel), '-d', str(destdir)], "python -m installer")
+
+    installed_py_files = destdir.rglob('*.py')
+
+    assert {f.stem for f in installed_py_files} == {'__init__', '__main__', 'data'}
+
+    installed_pyc_files = destdir.rglob('*.pyc')
+    assert {f.name.split('.')[0] for f in installed_pyc_files} == {
+        '__init__', '__main__'
+    }
+
+def test_main_no_pyc(fancy_wheel, tmp_path):
+    destdir = tmp_path / 'dest'
+
+    main([str(fancy_wheel), '-d', str(destdir), '--no-compile-bytecode'], "python -m installer")
+
+    installed_py_files = destdir.rglob('*.py')
+
+    assert {f.stem for f in installed_py_files} == {'__init__', '__main__', 'data'}
+
+    installed_pyc_files = destdir.rglob('*.pyc')
+    assert set(installed_pyc_files) == set()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,86 +1,10 @@
 import posixpath
-import sys
-import textwrap
 import zipfile
 
 import pytest
 
 from installer.records import parse_record_file
 from installer.sources import WheelFile, WheelSource
-
-
-@pytest.fixture
-def fancy_wheel(tmp_path):
-    path = tmp_path / "fancy-1.0.0-py2.py3-none-any.whl"
-    files = {
-        "fancy/": b"""""",
-        "fancy/__init__.py": b"""\
-            def main():
-                print("I'm fancy.")
-        """,
-        "fancy/__main__.py": b"""\
-            if __name__ == "__main__":
-                from . import main
-                main()
-        """,
-        "fancy-1.0.0.data/data/fancy/": b"""""",
-        "fancy-1.0.0.data/data/fancy/data.py": b"""\
-            # put me in data
-        """,
-        "fancy-1.0.0.dist-info/": b"""""",
-        "fancy-1.0.0.dist-info/top_level.txt": b"""\
-            fancy
-        """,
-        "fancy-1.0.0.dist-info/entry_points.txt": b"""\
-            [console_scripts]
-            fancy = fancy:main
-
-            [gui_scripts]
-            fancy-gui = fancy:main
-        """,
-        "fancy-1.0.0.dist-info/WHEEL": b"""\
-            Wheel-Version: 1.0
-            Generator: magic (1.0.0)
-            Root-Is-Purelib: true
-            Tag: py3-none-any
-        """,
-        "fancy-1.0.0.dist-info/METADATA": b"""\
-            Metadata-Version: 2.1
-            Name: fancy
-            Version: 1.0.0
-            Summary: A fancy package
-            Author: Agendaless Consulting
-            Author-email: nobody@example.com
-            License: MIT
-            Keywords: fancy amazing
-            Platform: UNKNOWN
-            Classifier: Intended Audience :: Developers
-        """,
-        # The RECORD file is indirectly validated by the WheelFile, since it only
-        # provides the items that are a part of the wheel.
-        "fancy-1.0.0.dist-info/RECORD": b"""\
-            fancy/__init__.py,,
-            fancy/__main__.py,,
-            fancy-1.0.0.data/data/fancy/data.py,,
-            fancy-1.0.0.dist-info/top_level.txt,,
-            fancy-1.0.0.dist-info/entry_points.txt,,
-            fancy-1.0.0.dist-info/WHEEL,,
-            fancy-1.0.0.dist-info/METADATA,,
-            fancy-1.0.0.dist-info/RECORD,,
-        """,
-    }
-
-    if sys.version_info <= (3, 6):
-        path = str(path)
-
-    with zipfile.ZipFile(path, "w") as archive:
-        for name, indented_content in files.items():
-            archive.writestr(
-                name,
-                textwrap.dedent(indented_content.decode("utf-8")).encode("utf-8"),
-            )
-
-    return path
 
 
 class TestWheelSource:


### PR DESCRIPTION
This starts from #66, and moves the added functionality for destdir & bytecode compilation into the Python API (`SchemeDictionaryDestination`), so the CLI is a thinner wrapper over the Python API. It also drops the compatibility checks, so `installer` once again has no dependencies.

Alternative to #92, for consideration.
Closes #93 