### PR TITLE
Refactor path handling to use pathlib.

### DIFF
--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -1,9 +1,9 @@
 """Installer CLI."""
 
 import argparse
-import os.path
 import sys
 import sysconfig
+from pathlib import Path
 from typing import Dict, Optional, Sequence
 
 import installer
@@ -15,12 +15,12 @@ import installer.utils
 def main_parser() -> argparse.ArgumentParser:
     """Construct the main parser."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("wheel", type=str, help="wheel file to install")
+    parser.add_argument("wheel", type=Path, help="wheel file to install")
     parser.add_argument(
         "--destdir",
         "-d",
         metavar="path",
-        type=str,
+        type=Path,
         help="destination directory (prefix to prepend to each file)",
     )
     parser.add_argument(
@@ -46,11 +46,12 @@ def get_scheme_dict(distribution_name: str) -> Dict[str, str]:
     # calculate 'headers' path, not currently in sysconfig - see
     # https://bugs.python.org/issue44445. This is based on what distutils does.
     # TODO: figure out original vs normalised distribution names
-    scheme_dict["headers"] = os.path.join(
-        sysconfig.get_path(
-            "include", vars={"installed_base": sysconfig.get_config_var("base")}
-        ),
-        distribution_name,
+    scheme_dict["headers"] = str(
+        Path(
+            sysconfig.get_path(
+                "include", vars={"installed_base": sysconfig.get_config_var("base")}
+            )
+        ).joinpath(distribution_name)
     )
 
     return scheme_dict

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -5,6 +5,7 @@ import posixpath
 import stat
 import zipfile
 from contextlib import contextmanager
+from pathlib import Path
 from typing import BinaryIO, Iterator, List, Tuple, cast
 
 import installer.records
@@ -108,7 +109,7 @@ class WheelFile(WheelSource):
         self._zipfile = f
         assert f.filename
 
-        basename = os.path.basename(f.filename)
+        basename = Path(f.filename).name
         parsed_name = installer.utils.parse_wheel_filename(basename)
         super().__init__(
             version=parsed_name.version,

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 from configparser import ConfigParser
 from email.message import Message
 from email.parser import FeedParser
+from pathlib import Path, PurePosixPath
 from typing import (
     TYPE_CHECKING,
     BinaryIO,
@@ -181,7 +182,7 @@ def fix_shebang(stream: BinaryIO, interpreter: str) -> Iterator[BinaryIO]:
 
 def construct_record_file(
     records: Iterable[Tuple[Scheme, RecordEntry]],
-    prefix_for_scheme: Callable[[Scheme], Optional[str]] = lambda _: None,
+    prefix_for_scheme: Callable[[Scheme], Optional[PurePosixPath]] = lambda _: None,
 ) -> BinaryIO:
     """Construct a RECORD file.
 
@@ -244,4 +245,4 @@ def _current_umask() -> int:
 # https://github.com/pypa/pip/blob/0f21fb92/src/pip/_internal/utils/unpacking.py#L93
 def make_file_executable(path: Union[str, "os.PathLike[str]"]) -> None:
     """Make the file at the provided path executable."""
-    os.chmod(path, (0o777 & ~_current_umask() | 0o111))
+    Path(path).chmod(0o777 & ~_current_umask() | 0o111)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,3 +1,5 @@
+from pathlib import PurePosixPath
+
 import pytest
 
 from installer.records import Hash, InvalidRecordEntry, RecordEntry, parse_record_file
@@ -152,7 +154,7 @@ class TestRecordEntry:
         expected_string_value = "prefix/" + ",".join(
             [(str(elem) if elem is not None else "") for elem in elements]
         )
-        assert record.to_line("prefix/") == expected_string_value.encode()
+        assert record.to_line(PurePosixPath("prefix/")) == expected_string_value.encode()
 
     def test_equality(self):
         record = RecordEntry.from_elements(

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -154,7 +154,9 @@ class TestRecordEntry:
         expected_string_value = "prefix/" + ",".join(
             [(str(elem) if elem is not None else "") for elem in elements]
         )
-        assert record.to_line(PurePosixPath("prefix/")) == expected_string_value.encode()
+        assert (
+            record.to_line(PurePosixPath("prefix/")) == expected_string_value.encode()
+        )
 
     def test_equality(self):
         record = RecordEntry.from_elements(


### PR DESCRIPTION
This should help reduce the amount of special casing needed for windows paths.