### PR TITLE
covert every path splitter \(Windows style) to /(Posix style).

### DIFF
--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -158,7 +158,10 @@ class WheelFile(WheelSource):
         :any:`AssertionError` will be raised.
         """
         # Convert the record file into a useful mapping
-        record_lines = [ line.replace("\\", "/") for line in self.read_dist_info("RECORD").splitlines()]
+        record_lines = [
+            line.replace("\\", "/")
+            for line in self.read_dist_info("RECORD").splitlines()
+        ]
         records = installer.records.parse_record_file(record_lines)
         record_mapping = {record[0]: record for record in records}
 

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -158,7 +158,7 @@ class WheelFile(WheelSource):
         :any:`AssertionError` will be raised.
         """
         # Convert the record file into a useful mapping
-        record_lines = self.read_dist_info("RECORD").splitlines()
+        record_lines = [ line.replace("\\", "/") for line in self.read_dist_info("RECORD").splitlines()]
         records = installer.records.parse_record_file(record_lines)
         record_mapping = {record[0]: record for record in records}
 


### PR DESCRIPTION
zipfile package unzip wheel and list of contents given by zipfile have their path splitter as '/'.
So if RECORD contain any path splitted by '\', install will be failed.
Indeed, RECORD of some packages wheel (.whl) in pypi have their path splitter as either '/' or '\'.